### PR TITLE
declare correct package version in spec file

### DIFF
--- a/pulp-docker.spec
+++ b/pulp-docker.spec
@@ -2,8 +2,8 @@
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 
 Name: pulp-docker
-Version: 0.2.0
-Release: 1%{?dist}
+Version: 0.2.1
+Release: 0.1.alpha%{?dist}
 Summary: Support for Docker layers in the Pulp platform
 Group: Development/Languages
 License: GPLv2


### PR DESCRIPTION
Updating version in spec to better follow
https://fedoraproject.org/wiki/Packaging:NamingGuidelines#NonNumericRelease.
This is what the other pulp packages use.
