### PR TITLE
1150592 - set default auto-publish value

### DIFF
--- a/extensions_admin/pulp_docker/extensions/admin/cudl.py
+++ b/extensions_admin/pulp_docker/extensions/admin/cudl.py
@@ -15,7 +15,7 @@ from pulp_docker.extensions.admin import parsers as docker_parsers
 d = _('if "true", on each successful sync the repository will automatically be '
       'published; if "false" content will only be available after manually publishing '
       'the repository; defaults to "true"')
-OPT_AUTO_PUBLISH = PulpCliOption('--auto-publish', d, required=False,
+OPT_AUTO_PUBLISH = PulpCliOption('--auto-publish', d, required=False, default='true',
                                  parse_func=parsers.parse_boolean)
 
 d = _('The URL that will be used when generating the redirect map for connecting the docker '
@@ -87,7 +87,7 @@ class CreateDockerRepositoryCommand(CreateAndConfigureRepositoryCommand, Importe
         if value is not None:
             config[constants.CONFIG_KEY_REPO_REGISTRY_ID] = value
 
-        auto_publish = user_input.get('auto-publish', True)
+        auto_publish = user_input.get(OPT_AUTO_PUBLISH.keyword, True)
         data = [
             dict(distributor_type_id=constants.DISTRIBUTOR_WEB_TYPE_ID,
                  distributor_config=config,

--- a/extensions_admin/pulp_docker/extensions/admin/repo_list.py
+++ b/extensions_admin/pulp_docker/extensions/admin/repo_list.py
@@ -37,13 +37,6 @@ class ListDockerRepositoriesCommand(ListRepositoriesCommand):
                     and notes[pulp_constants.REPO_NOTE_TYPE_KEY] == constants.REPO_NOTE_DOCKER:
                 docker_repos.append(repo)
 
-        # There isn't really anything compelling in the exporter distributor
-        # to display to the user, so remove it entirely.
-        for r in docker_repos:
-            if 'distributors' in r:
-                r['distributors'] = \
-                    [x for x in r['distributors'] if x['id'] == constants.CLI_EXPORT_DISTRIBUTOR_ID]
-
         return docker_repos
 
     def get_other_repositories(self, query_params, **kwargs):

--- a/extensions_admin/test/unit/extensions/admin/test_repo_list.py
+++ b/extensions_admin/test/unit/extensions/admin/test_repo_list.py
@@ -53,9 +53,8 @@ class TestListDockerRepositoriesCommand(unittest.TestCase):
         self.assertEqual(1, len(repos))
         self.assertEqual(repos[0]['id'], 'matching')
 
-        #   Make sure the export distributor was removed
-        self.assertEqual(len(repos[0]['distributors']), 1)
-        self.assertEqual(repos[0]['distributors'][0]['id'], constants.CLI_EXPORT_DISTRIBUTOR_ID)
+        #   Make sure two distributors exist
+        self.assertEqual(len(repos[0]['distributors']), 2)
 
     def test_get_repositories_no_details(self):
         # Setup


### PR DESCRIPTION
The PulpCliOption default for auto-publish was not set. Additionally, I altered
the distributor list behavior so the exporter distributor is now printed (per @barnabycourt)
