### PR TITLE
1148556 - Validate repo-registry-id to ensure compatibility with Docker

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
+Randy Barlow (rbarlow@redhat.com)
 Barnaby Court (bcourt@redhat.com)
 Michael Hrivnak (mhrivnak@redhat.com)
-Randy Barlow (rbarlow@redhat.com)
 Sayli Karmarkar (skarmark@redhat.com)
+Austin Macdonald (amacdona@redhat.com)

--- a/common/pulp_docker/common/error_codes.py
+++ b/common/pulp_docker/common/error_codes.py
@@ -8,5 +8,13 @@ DKR1002 = Error("DKR1002", _("The url specified for %(field) is missing a hostna
                              "The value specified is '%(url)'."), ['field', 'url'])
 DKR1003 = Error("DKR1003", _("The url specified for %(field) is missing a path. "
                              "The value specified is '%(url)'."), ['field', 'url'])
-DKR1004 = Error("DKR1004", _("The value specified for %(field): '%(value)s' is not boolean."),
+DKR1004 = Error("DKR1004", _("The value specified for %(field)s: '%(value)s' is not boolean."),
                 ['field', 'value'])
+DKR1005 = Error("DKR1005", _(
+    "The value specified for %(field)s: '%(value)s' is invalid. Registry id must contain only "
+    "lower case letters, integers, hyphens, and periods."),
+    ['field', 'value'])
+DKR1006 = Error("DKR1006", _(
+    "If %(field)s is not specified, it will default to the id must contain only lower case letters,"
+    " integers, hyphens, and periods. Please either specify a registry id or change the repo id."),
+    ['field', 'value'])

--- a/plugins/pulp_docker/plugins/distributors/distributor_export.py
+++ b/plugins/pulp_docker/plugins/distributors/distributor_export.py
@@ -92,7 +92,7 @@ class DockerExportDistributor(Distributor):
         :return: tuple of (bool, str) to describe the result
         :rtype:  tuple
         """
-        return configuration.validate_config(config)
+        return configuration.validate_config(config, repo)
 
     def publish_repo(self, repo, publish_conduit, config):
         """

--- a/plugins/pulp_docker/plugins/distributors/distributor_web.py
+++ b/plugins/pulp_docker/plugins/distributors/distributor_web.py
@@ -92,7 +92,7 @@ class DockerWebDistributor(Distributor):
         :return: tuple of (bool, str) to describe the result
         :rtype:  tuple
         """
-        return configuration.validate_config(config)
+        return configuration.validate_config(config, repo)
 
     def publish_repo(self, repo, publish_conduit, config):
         """

--- a/plugins/test/unit/plugins/distributors/test_distributor_export.py
+++ b/plugins/test/unit/plugins/distributors/test_distributor_export.py
@@ -45,8 +45,9 @@ class TestBasics(unittest.TestCase):
 
     @patch('pulp_docker.plugins.distributors.distributor_export.configuration.validate_config')
     def test_validate_config(self, mock_validate):
-        value = self.distributor.validate_config(Mock(), 'foo', Mock())
-        mock_validate.assert_called_once_with('foo')
+        repo = Mock()
+        value = self.distributor.validate_config(repo, 'foo', Mock())
+        mock_validate.assert_called_once_with('foo', repo)
         self.assertEquals(value, mock_validate.return_value)
 
     @patch('pulp_docker.plugins.distributors.distributor_export.configuration.'

--- a/plugins/test/unit/plugins/distributors/test_distributor_web.py
+++ b/plugins/test/unit/plugins/distributors/test_distributor_web.py
@@ -45,8 +45,9 @@ class TestBasics(unittest.TestCase):
 
     @patch('pulp_docker.plugins.distributors.distributor_web.configuration.validate_config')
     def test_validate_config(self, mock_validate):
-        value = self.distributor.validate_config(Mock(), 'foo', Mock())
-        mock_validate.assert_called_once_with('foo')
+        repo = Mock()
+        value = self.distributor.validate_config(repo, 'foo', Mock())
+        mock_validate.assert_called_once_with('foo', repo)
         self.assertEquals(value, mock_validate.return_value)
 
     @patch('pulp_docker.plugins.distributors.distributor_web.configuration.get_app_publish_dir')


### PR DESCRIPTION
[BZ -1148556](https://bugzilla.redhat.com/show_bug.cgi?id=1148556)

Docker registry id's cannot contain uppercase letters, so they should be validated. If the repo-registry-id is not specified, it defaults to repo id, so in that case, the repo-id needs to be validated differently.

This PR gives a less than ideal error back to the user. This problem is fixed in https://github.com/pulp/pulp/pull/1487