### PR TITLE
1148556 - part2 - repo registry ids may contain slashes

### DIFF
--- a/common/pulp_docker/common/error_codes.py
+++ b/common/pulp_docker/common/error_codes.py
@@ -12,9 +12,10 @@ DKR1004 = Error("DKR1004", _("The value specified for %(field)s: '%(value)s' is 
                 ['field', 'value'])
 DKR1005 = Error("DKR1005", _(
     "The value specified for %(field)s: '%(value)s' is invalid. Registry id must contain only "
-    "lower case letters, integers, hyphens, and periods."),
+    "lower case letters, integers, hyphens, periods, and may include a single slash."),
     ['field', 'value'])
 DKR1006 = Error("DKR1006", _(
     "If %(field)s is not specified, it will default to the id must contain only lower case letters,"
-    " integers, hyphens, and periods. Please either specify a registry id or change the repo id."),
+    " integers, hyphens, periods, and may include a single slash. Please specify a valid registry "
+    "id or change the repo id."),
     ['field', 'value'])

--- a/plugins/pulp_docker/plugins/distributors/configuration.py
+++ b/plugins/pulp_docker/plugins/distributors/configuration.py
@@ -236,11 +236,11 @@ def get_repo_registry_id(repo, config):
 def _is_valid_repo_registry_id(repo_registry_id):
     """
     Docker registry repos are restricted to lower case letters, numbers, hyphens, underscores, and
-    periods.
+    periods. Additionally, we allow a single slash for namespacing purposes.
 
     :param repo_registry_id: Docker registry id
     :type  repo_registry_id: basestring
     :return:                 True if valid, False if invalid
     :rtype:                  boolean
     """
-    return bool(re.match(r"^[a-z0-9-_.]*$", repo_registry_id))
+    return bool(re.match(r"^[a-z0-9-_.]*/?[a-z0-9-_.]*$", repo_registry_id))

--- a/plugins/test/unit/plugins/distributors/test_configuration.py
+++ b/plugins/test/unit/plugins/distributors/test_configuration.py
@@ -76,6 +76,27 @@ class TestValidateConfig(unittest.TestCase):
         assert_validation_exception(configuration.validate_config,
                                     [error_codes.DKR1004], config, repo)
 
+    def test_repo_regisrty_id_with_slash(self):
+        """
+        We need to allow a single slash in this field to allow namespacing.
+        """
+        config = PluginCallConfiguration({
+            constants.CONFIG_KEY_REPO_REGISTRY_ID: 'slashes/ok'
+        }, {})
+        repo = Mock(id='repoid')
+        self.assertEquals((True, None), configuration.validate_config(config, repo))
+
+    def test_repo_regisrty_id_with_multiple_slashes(self):
+        """
+        We need to allow only one slash.
+        """
+        config = PluginCallConfiguration({
+            constants.CONFIG_KEY_REPO_REGISTRY_ID: 'slashes/ok/notok'
+        }, {})
+        repo = Mock(id='repoid')
+        assert_validation_exception(configuration.validate_config,
+                                    [error_codes.DKR1005], config, repo)
+
     def test_invalid_repo_registry_id(self):
         config = PluginCallConfiguration({
             constants.CONFIG_KEY_REPO_REGISTRY_ID: 'noUpperCase'


### PR DESCRIPTION
Docker repository names may only contain letters numbers, hyphens, underscores, and periods; however, the `repo_registry_id` field in pulp can also contain a namespace, ex `namespace/repo_name`, so the validation should allow a single slash.