### PR TITLE
Failure to sync no longer logs tracebacks, also reports a more helpful message

### DIFF
--- a/common/pulp_docker/common/error_codes.py
+++ b/common/pulp_docker/common/error_codes.py
@@ -19,3 +19,5 @@ DKR1006 = Error("DKR1006", _(
     " integers, hyphens, periods, and may include a single slash. Please specify a valid registry "
     "id or change the repo id."),
     ['field', 'value'])
+DKR1007 = Error("DKR1007", _("Could not fetch repository %(repo)s from registry %(registry)s"),
+                ['repo', 'registry'])

--- a/pulp-docker.spec
+++ b/pulp-docker.spec
@@ -76,7 +76,7 @@ rm -rf %{buildroot}
 %package -n python-pulp-docker-common
 Summary: Pulp Docker support common library
 Group: Development/Languages
-Requires: python-pulp-common >= 2.5.0
+Requires: python-pulp-common >= 2.7.0
 Requires: python-setuptools
 
 %description -n python-pulp-docker-common
@@ -97,9 +97,9 @@ Common libraries for python-pulp-docker
 %package plugins
 Summary: Pulp Docker plugins
 Group: Development/Languages
-Requires: python-pulp-common >= 2.5.0
+Requires: python-pulp-common >= 2.7.0
 Requires: python-pulp-docker-common = %{version} 
-Requires: pulp-server >= 2.5.0
+Requires: pulp-server >= 2.7.0
 Requires: python-setuptools
 Requires: python-nectar >= 1.3.0
 
@@ -125,9 +125,9 @@ to provide Docker specific support
 %package admin-extensions
 Summary: The Pulp Docker admin client extensions
 Group: Development/Languages
-Requires: python-pulp-common >= 2.5.0
+Requires: python-pulp-common >= 2.7.0
 Requires: python-pulp-docker-common = %{version}
-Requires: pulp-admin-client >= 2.5.0
+Requires: pulp-admin-client >= 2.7.0
 Requires: python-setuptools
 
 %description admin-extensions


### PR DESCRIPTION
This depends on changes in pulp that better-handle PulpCodedException reporting.

fixes #702
refs #652

https://pulp.plan.io/issues/652
https://pulp.plan.io/issues/702

https://github.com/pulp/pulp/pull/1772