### PR TITLE
Correct the repo-registry-id validation error

### DIFF
--- a/common/pulp_docker/common/error_codes.py
+++ b/common/pulp_docker/common/error_codes.py
@@ -15,7 +15,7 @@ DKR1005 = Error("DKR1005", _(
     "lower case letters, integers, hyphens, periods, and may include a single slash."),
     ['field', 'value'])
 DKR1006 = Error("DKR1006", _(
-    "If %(field)s is not specified, it will default to the id must contain only lower case letters,"
-    " integers, hyphens, periods, and may include a single slash. Please specify a valid registry "
-    "id or change the repo id."),
+    "%(field)s may only contain lower case letters, integers, hyphens, periods, and may include "
+    "a single slash. When %(field)s is not specified, the repo-id value is used. In that case the "
+    "repo-id needs to adhere to the same requirements as %(field)s."),
     ['field', 'value'])


### PR DESCRIPTION
Fixes the wording of an error message.

re: 291

https://pulp.plan.io/issues/291