### PR TITLE
Create a new Blob model.

### DIFF
--- a/common/pulp_docker/common/models.py
+++ b/common/pulp_docker/common/models.py
@@ -7,23 +7,72 @@ import json
 from pulp_docker.common import constants
 
 
+class Blob(object):
+    """
+    This class is used to represent Docker v2 blobs.
+    """
+    TYPE_ID = 'docker_blob'
+
+    def __init__(self, digest):
+        """
+        Initialize the Blob.
+
+        :param image_id:    This field will store the blob's digest.
+        :type  image_id:    basestring
+        """
+        self.digest = digest
+
+    @property
+    def unit_key(self):
+        """
+        Return the Blob's unit key.
+
+        :return:    unit key
+        :rtype:     dict
+        """
+        return {
+            'digest': self.digest
+        }
+
+    @property
+    def metadata(self):
+        """
+        A blob has no metadata, so return an empty dictionary.
+
+        :return: Empty dictionary
+        :rtype:  dict
+        """
+        return {}
+
+    @property
+    def relative_path(self):
+        """
+        Return the Blob's relative path for filesystem storage.
+
+        :return:    the relative path to where this Blob should live
+        :rtype:     basestring
+        """
+        return self.digest
+
+
 class Image(object):
     """
-    This class is used to represent Docker v1 images and Docker v2 blobs.
+    This class is used to represent Docker v1 images.
     """
     TYPE_ID = constants.IMAGE_TYPE_ID
 
     def __init__(self, image_id, parent_id, size):
         """
-        :param image_id:    For Docker v1 images, this field will store the image_id. For Docker v2
-                            blobs, this field will store the blob's digest.
-        :type  image_id:    basestring
-        :param parent_id:   parent's unique image ID
-        :type  parent_id:   basestring
-        :param size:        size of the image in bytes, as reported by docker.
-                            This can be None, because some very old docker images
-                            do not contain it in their metadata.
-        :type  size:        int or NoneType
+        Initialize the Image.
+
+        :param image_id:  The Image's id.
+        :type  image_id:  basestring
+        :param parent_id: parent's unique image ID
+        :type  parent_id: basestring
+        :param size:      size of the image in bytes, as reported by docker.
+                          This can be None, because some very old docker images
+                          do not contain it in their metadata.
+        :type  size:      int or NoneType
         """
         self.image_id = image_id
         self.parent_id = parent_id
@@ -32,6 +81,8 @@ class Image(object):
     @property
     def unit_key(self):
         """
+        Return the Image's unit key.
+
         :return:    unit key
         :rtype:     dict
         """
@@ -42,6 +93,8 @@ class Image(object):
     @property
     def relative_path(self):
         """
+        Return the Image's relative path for filesystem storage.
+
         :return:    the relative path to where this image's directory should live
         :rtype:     basestring
         """
@@ -50,6 +103,8 @@ class Image(object):
     @property
     def unit_metadata(self):
         """
+        Return the Image's Metadata.
+
         :return:    a subset of the complete docker metadata about this image,
                     including only what pulp_docker cares about
         :rtype:     dict
@@ -86,9 +141,9 @@ class Manifest(object):
         :param architecture:   The host architecture on which the image is intended to run
         :type  architecture:   basestring
         :param fs_layers:      A list of dictionaries. Each dictionary contains one key-value pair
-                               that represents a layer of the image. The key is blobSum, and the
-                               value is the digest of the referenced layer. See the documentation
-                               referenced in the class docblock for more information.
+                               that represents a layer (a Blob) of the image. The key is blobSum,
+                               and the value is the digest of the referenced layer. See the
+                               documentation referenced in the class docblock for more information.
         :type  fs_layers:      list
         :param history:        This is a list of unstructured historical data for v1 compatibility.
                                Each member is a dictionary with a "v1Compatibility" key that indexes

--- a/common/test/unit/test_models.py
+++ b/common/test/unit/test_models.py
@@ -34,6 +34,57 @@ class TestBasics(unittest.TestCase):
         self.assertEqual(metadata.get('size'), 1024)
 
 
+class TestBlob(unittest.TestCase):
+    """
+    This class contains tests for the Blob class.
+    """
+    def test___init__(self):
+        """
+        Assert correct behavior from the __init__() method.
+        """
+        digest = 'sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef'
+
+        blob = models.Blob(digest)
+
+        self.assertEqual(blob.digest, digest)
+
+    def test_type_id(self):
+        """
+        Assert that the TYPE_ID attribute is correct.
+        """
+        self.assertEqual(models.Blob.TYPE_ID, 'docker_blob')
+
+    def test_unit_key(self):
+        """
+        Assert correct behavior from the unit_key() method.
+        """
+        digest = 'sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef'
+
+        blob = models.Blob(digest)
+
+        self.assertEqual(blob.unit_key, {'digest': digest})
+
+    def test_metadata(self):
+        """
+        Assert correct behavior from the metadata() method.
+        """
+        digest = 'sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef'
+
+        blob = models.Blob(digest)
+
+        self.assertEqual(blob.metadata, {})
+
+    def test_relative_path(self):
+        """
+        Assert correct behavior from the relative_path() method.
+        """
+        digest = 'sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef'
+
+        blob = models.Blob(digest)
+
+        self.assertEqual(blob.relative_path, digest)
+
+
 class TestManifest(unittest.TestCase):
     """
     This class contains tests for the Manifest class.

--- a/plugins/test/unit/plugins/importers/test_v1_sync.py
+++ b/plugins/test/unit/plugins/importers/test_v1_sync.py
@@ -13,12 +13,31 @@ from pulp.plugins.model import Repository as RepositoryModel, Unit
 from pulp.server.exceptions import MissingValue
 from pulp.server.managers import factory
 
-from pulp_docker.common import constants
+from pulp_docker.common import constants, models
 from pulp_docker.plugins.importers import v1_sync
 from pulp_docker.plugins import registry
 
 
 factory.initialize()
+
+
+class TestGetLocalImagesStep(unittest.TestCase):
+    """
+    This class contains tests for the GetLocalImagesStep class.
+    """
+    def test__dict_to_unit(self):
+        """
+        Assert correct behavior from the _dict_to_unit() method.
+        """
+        step = v1_sync.GetLocalImagesStep(constants.IMPORTER_TYPE_ID, models.Image.TYPE_ID,
+                                          ['image_id'], '/working/dir')
+        step.conduit = mock.MagicMock()
+
+        unit = step._dict_to_unit({'image_id': 'abc123'})
+
+        self.assertTrue(unit is step.conduit.init_unit.return_value)
+        step.conduit.init_unit.assert_called_once_with(
+            models.Image.TYPE_ID, {'image_id': 'abc123'}, {}, 'abc123')
 
 
 class TestSyncStep(unittest.TestCase):

--- a/plugins/types/docker.json
+++ b/plugins/types/docker.json
@@ -1,5 +1,12 @@
 {"types": [
     {
+        "id": "docker_blob",
+        "display_name": "Docker Blob",
+        "description": "Docker Blob",
+        "unit_key": ["digest"],
+        "search_indexes": []
+    },
+    {
         "id": "docker_image",
         "display_name": "Docker Image",
         "description": "Docker Image",


### PR DESCRIPTION
This commit introduces a new Unit type called Blob, and converts the
Docker v2 sync code to use it instead of overloading the Image model
that is also used by v1 sync and publish. This will simplify the
concepts in Pulp and make the v2 distributor easier to write.
Conveniently, it also separates the locations of the Units on the
filesystem as well.

https://pulp.plan.io/issues/967

re #967