### PR TITLE
Serve Docker v2 at /pulp/docker/v2 instead of /v2.

### DIFF
--- a/plugins/etc/httpd/conf.d/pulp_docker.conf
+++ b/plugins/etc/httpd/conf.d/pulp_docker.conf
@@ -5,16 +5,18 @@
 # -- HTTPS Repositories ---------
 
 # Docker v2
-
-Alias /v2 /var/www/pub/docker/v2/web
+Alias /pulp/docker/v2 /var/www/pub/docker/v2/web
 
 <Directory /var/www/pub/docker/v2/web>
+    SSLRequireSSL
+    SSLVerifyClient optional_no_ca
+    SSLVerifyDepth 2
+    SSLOptions +StdEnvVars +ExportCertData +FakeBasicAuth
     Options FollowSymlinks Indexes
 </Directory>
 
 # Docker v1
-
-Alias /pulp/docker /var/www/pub/docker/v1/web
+Alias /pulp/docker/v1 /var/www/pub/docker/v1/web
 
 <Directory /var/www/pub/docker/v1/web>
     SSLRequireSSL


### PR DESCRIPTION
This commit adjusts our Docker v2 endpoint to be served at
/pulp/docker/v2 instead of just /v2. It was necessary to also adjust the
Docker v1 endpoint to be /pulp/docker/v1 instead of just /pulp/docker.
This is a backwards-incompatible change.

The Docker v1 endpoint was configured to require SSL. The v2 endpoint is currently configured to allow plaintext and SSL. Should we configure v2 to similarly require SSL?