### PR TITLE
Command and section layout consistent with other plugins.

### DIFF
--- a/extensions_admin/pulp_docker/extensions/admin/images.py
+++ b/extensions_admin/pulp_docker/extensions/admin/images.py
@@ -32,7 +32,7 @@ def get_formatter_for_type(type_id):
 
 class ImageCopyCommand(UnitCopyCommand):
 
-    def __init__(self, context, name='copy', description=DESC_COPY):
+    def __init__(self, context, name='image', description=DESC_COPY):
         super(ImageCopyCommand, self).__init__(context, name=name, description=description,
                                                method=self.run, type_id=constants.IMAGE_TYPE_ID)
 
@@ -54,7 +54,7 @@ class ImageRemoveCommand(UnitRemoveCommand):
     Class for executing unit remove commands for docker image units
     """
 
-    def __init__(self, context, name='remove', description=DESC_REMOVE):
+    def __init__(self, context, name='image', description=DESC_REMOVE):
         UnitRemoveCommand.__init__(self, context, name=name, description=description,
                                    type_id=constants.IMAGE_TYPE_ID)
 
@@ -73,7 +73,7 @@ class ImageRemoveCommand(UnitRemoveCommand):
 
 class ImageSearchCommand(DisplayUnitAssociationsCommand):
     def __init__(self, context):
-        super(ImageSearchCommand, self).__init__(self.run, name='images', description=DESC_SEARCH)
+        super(ImageSearchCommand, self).__init__(self.run, name='image', description=DESC_SEARCH)
         self.context = context
         self.prompt = context.prompt
 

--- a/extensions_admin/pulp_docker/extensions/admin/manifest.py
+++ b/extensions_admin/pulp_docker/extensions/admin/manifest.py
@@ -43,7 +43,7 @@ class ManifestSearchCommand(DisplayUnitAssociationsCommand):
         :type  context: pulp.client.extensions.core.ClientContext
         """
         super(ManifestSearchCommand, self).__init__(
-            name='search',
+            name='manifest',
             description=DESC_SEARCH,
             method=self.run)
         self.context = context
@@ -75,7 +75,7 @@ class ManifestCopyCommand(UnitCopyCommand):
         """
         super(ManifestCopyCommand, self).__init__(
             context,
-            name='copy',
+            name='manifest',
             description=DESC_COPY,
             method=self.run,
             type_id=Manifest.TYPE_ID)
@@ -105,7 +105,7 @@ class ManifestRemoveCommand(UnitRemoveCommand):
         :type  context: pulp.client.extensions.core.ClientContext
         """
         super(ManifestRemoveCommand, self).__init__(
-            name='remove',
+            name='manifest',
             description=DESC_REMOVE,
             context=context,
             method=self.run,

--- a/extensions_admin/pulp_docker/extensions/admin/pulp_cli.py
+++ b/extensions_admin/pulp_docker/extensions/admin/pulp_cli.py
@@ -38,6 +38,15 @@ DESC_EXPORT_FILE = _('the full path for an export file; if specified, the reposi
                      'exported as a tar file to the given file on the server.  '
                      'The web server\'s user must have the permission to write the file specified.')
 
+SECTION_SEARCH = 'search'
+DESC_SEARCH = _('content search commands')
+
+SECTION_COPY = 'copy'
+DESC_COPY = _('content copy commands')
+
+SECTION_REMOVE = 'remove'
+DESC_REMOVE = _('content removal commands')
+
 SECTION_MANIFEST = 'manifest'
 DESC_MANIFEST = _('manifest management commands')
 
@@ -69,9 +78,7 @@ def add_upload_section(context, parent_section):
     :type  parent_section:  pulp.client.extensions.extensions.PulpCliSection
     """
     upload_section = parent_section.create_subsection(SECTION_UPLOADS, DESC_UPLOADS)
-
     upload_section.add_command(UploadDockerImageCommand(context))
-
     return upload_section
 
 
@@ -85,33 +92,62 @@ def add_repo_section(context, parent_section):
     :type  parent_section:  pulp.client.extensions.extensions.PulpCliSection
     """
     repo_section = parent_section.create_subsection(SECTION_REPO, DESC_REPO)
-
     repo_section.add_command(CreateDockerRepositoryCommand(context))
     repo_section.add_command(cudl.DeleteRepositoryCommand(context))
     repo_section.add_command(UpdateDockerRepositoryCommand(context))
-    repo_section.add_command(ImageRemoveCommand(context))
-    repo_section.add_command(ImageCopyCommand(context))
-    repo_section.add_command(ImageSearchCommand(context))
     repo_section.add_command(ListDockerRepositoriesCommand(context))
-    add_manifest_section(context, repo_section)
-
+    add_search_section(context, repo_section)
+    add_copy_section(context, repo_section)
+    add_remove_section(context, repo_section)
     return repo_section
 
 
-def add_manifest_section(context, parent_section):
+def add_search_section(context, parent_section):
     """
-    Add a manifest section to the parent section.
+    Add the search section to the parent section.
 
     :param context: pulp context
     :type  context: pulp.client.extensions.core.ClientContext
-    :param parent_section: section of the CLI to which the manifest section
+    :param parent_section: section of the CLI to which the this section
         should be added
     :type  parent_section: pulp.client.extensions.extensions.PulpCliSection
     """
-    section = parent_section.create_subsection(SECTION_MANIFEST, DESC_MANIFEST)
+    section = parent_section.create_subsection(SECTION_SEARCH, DESC_SEARCH)
+    section.add_command(ImageSearchCommand(context))
     section.add_command(ManifestSearchCommand(context))
+    return section
+
+
+def add_copy_section(context, parent_section):
+    """
+    Add the copy section to the parent section.
+
+    :param context: pulp context
+    :type  context: pulp.client.extensions.core.ClientContext
+    :param parent_section: section of the CLI to which the this section
+        should be added
+    :type  parent_section: pulp.client.extensions.extensions.PulpCliSection
+    """
+    section = parent_section.create_subsection(SECTION_COPY, DESC_COPY)
+    section.add_command(ImageCopyCommand(context))
     section.add_command(ManifestCopyCommand(context))
+    return section
+
+
+def add_remove_section(context, parent_section):
+    """
+    Add the remove section to the parent section.
+
+    :param context: pulp context
+    :type  context: pulp.client.extensions.core.ClientContext
+    :param parent_section: section of the CLI to which the this section
+        should be added
+    :type  parent_section: pulp.client.extensions.extensions.PulpCliSection
+    """
+    section = parent_section.create_subsection(SECTION_REMOVE, DESC_REMOVE)
+    section.add_command(ImageRemoveCommand(context))
     section.add_command(ManifestRemoveCommand(context))
+    return section
 
 
 def add_sync_section(context, parent_section):

--- a/extensions_admin/test/unit/extensions/admin/test_manifest.py
+++ b/extensions_admin/test/unit/extensions/admin/test_manifest.py
@@ -36,7 +36,7 @@ class TestManifestSearchCommand(TestCase):
         context = Mock()
         command = ManifestSearchCommand(context)
         self.assertEqual(command.context, context)
-        self.assertEqual(command.name, 'search')
+        self.assertEqual(command.name, 'manifest')
         self.assertEqual(command.prompt, context.prompt)
         self.assertFalse(command.description is None)
         self.assertEqual(command.method, command.run)
@@ -64,7 +64,7 @@ class TestManifestCopyCommand(TestCase):
     def test_init(self):
         context = Mock(config={'output': {'poll_frequency_in_seconds': 10}})
         command = ManifestCopyCommand(context)
-        self.assertEqual(command.name, 'copy')
+        self.assertEqual(command.name, 'manifest')
         self.assertFalse(command.description is None)
         self.assertEqual(command.context, context)
         self.assertEqual(command.method, command.run)
@@ -82,7 +82,7 @@ class TestManifestRemoveCommand(TestCase):
     def test_init(self):
         context = Mock(config={'output': {'poll_frequency_in_seconds': 10}})
         command = ManifestRemoveCommand(context)
-        self.assertEqual(command.name, 'remove')
+        self.assertEqual(command.name, 'manifest')
         self.assertFalse(command.description is None)
         self.assertEqual(command.context, context)
         self.assertEqual(command.method, command.run)

--- a/extensions_admin/test/unit/extensions/admin/test_pulp_cli.py
+++ b/extensions_admin/test/unit/extensions/admin/test_pulp_cli.py
@@ -1,15 +1,19 @@
 import unittest
 
 import mock
+
 from pulp.client.commands.repo.cudl import CreateRepositoryCommand, DeleteRepositoryCommand
 from pulp.client.commands.repo.cudl import UpdateRepositoryCommand
 from pulp.client.commands.repo.sync_publish import PublishStatusCommand,\
     RunPublishRepositoryCommand, RunSyncRepositoryCommand
 from pulp.client.commands.repo.upload import UploadCommand
 from pulp.client.extensions.core import PulpCli
+from pulp.client.extensions.extensions import PulpCliSection
+
 
 from pulp_docker.extensions.admin import pulp_cli
 from pulp_docker.extensions.admin import images
+from pulp_docker.extensions.admin import manifest
 from pulp_docker.extensions.admin.repo_list import ListDockerRepositoriesCommand
 
 
@@ -25,7 +29,7 @@ class TestInitialize(unittest.TestCase):
         # create the tree of commands and sections
         pulp_cli.initialize(context)
 
-        # verify that sections exist and have the right commands
+        # verify that sections exist and have the right commands and sections
         docker_section = context.cli.root_section.subsections['docker']
 
         repo_section = docker_section.subsections['repo']
@@ -33,9 +37,9 @@ class TestInitialize(unittest.TestCase):
         self.assertTrue(isinstance(repo_section.commands['delete'], DeleteRepositoryCommand))
         self.assertTrue(isinstance(repo_section.commands['update'], UpdateRepositoryCommand))
         self.assertTrue(isinstance(repo_section.commands['list'], ListDockerRepositoriesCommand))
-        self.assertTrue(isinstance(repo_section.commands['images'], images.ImageSearchCommand))
-        self.assertTrue(isinstance(repo_section.commands['copy'], images.ImageCopyCommand))
-        self.assertTrue(isinstance(repo_section.commands['remove'], images.ImageRemoveCommand))
+        self.assertTrue(isinstance(repo_section.subsections['search'], PulpCliSection))
+        self.assertTrue(isinstance(repo_section.subsections['copy'], PulpCliSection))
+        self.assertTrue(isinstance(repo_section.subsections['remove'], PulpCliSection))
 
         upload_section = repo_section.subsections['uploads']
         self.assertTrue(isinstance(upload_section.commands['upload'], UploadCommand))
@@ -50,3 +54,15 @@ class TestInitialize(unittest.TestCase):
         section = repo_section.subsections['export']
         self.assertTrue(isinstance(section.commands['status'], PublishStatusCommand))
         self.assertTrue(isinstance(section.commands['run'], RunPublishRepositoryCommand))
+
+        section = repo_section.subsections['search']
+        self.assertTrue(isinstance(section.commands['image'], images.ImageSearchCommand))
+        self.assertTrue(isinstance(section.commands['manifest'], manifest.ManifestSearchCommand))
+
+        section = repo_section.subsections['copy']
+        self.assertTrue(isinstance(section.commands['image'], images.ImageCopyCommand))
+        self.assertTrue(isinstance(section.commands['manifest'], manifest.ManifestCopyCommand))
+
+        section = repo_section.subsections['remove']
+        self.assertTrue(isinstance(section.commands['image'], images.ImageRemoveCommand))
+        self.assertTrue(isinstance(section.commands['manifest'], manifest.ManifestRemoveCommand))


### PR DESCRIPTION
https://pulp.plan.io/issues/1219

Now that docker 2.0 repositories contain multiple content types (images, manifests), the repo sections and commands needed to be rearranged as:

```
pulp-admin docker repo search (image|manifest)
pulp-admin docker repo copy (image|manifest)
pulp-admin docker repo remove (image|manifest)
```

Instead of:

```
pulp-admin docker repo images
pulp-admin docker repo copy
pulp-admin docker repo remove
pulp-admin docker repo manifest search
pulp-admin docker repo manifest copy
pulp-admin docker repo manifest remove
```
