### PR TITLE
Add a migration for users to move to pulp-docker-2

### DIFF
--- a/common/pulp_docker/common/models.py
+++ b/common/pulp_docker/common/models.py
@@ -3,6 +3,7 @@ This module contains common model objects that are used to describe the data typ
 pulp_docker plugins.
 """
 import json
+import os
 
 from pulp_docker.common import constants
 
@@ -98,7 +99,7 @@ class Image(object):
         :return:    the relative path to where this image's directory should live
         :rtype:     basestring
         """
-        return self.image_id
+        return os.path.join(self.TYPE_ID, self.image_id)
 
     @property
     def unit_metadata(self):

--- a/common/test/unit/test_models.py
+++ b/common/test/unit/test_models.py
@@ -24,7 +24,7 @@ class TestBasics(unittest.TestCase):
     def test_relative_path(self):
         image = models.Image('abc', 'xyz', 1024)
 
-        self.assertEqual(image.relative_path, 'abc')
+        self.assertEqual(image.relative_path, 'docker_image/abc')
 
     def test_metadata(self):
         image = models.Image('abc', 'xyz', 1024)

--- a/plugins/pulp_docker/plugins/migrations/0001_v2_support.py
+++ b/plugins/pulp_docker/plugins/migrations/0001_v2_support.py
@@ -1,0 +1,81 @@
+"""
+This migration moves the published content from /var/lib/pulp/published/docker/ to
+/var/lib/pulp/published/docker/v1/.
+"""
+import os
+import shutil
+
+from pulp.plugins.util import misc
+
+
+OLD_DOCKER_V1_PUBLISH_PATH = os.path.join('/', 'var', 'lib', 'pulp', 'published', 'docker')
+NEW_DOCKER_V1_PUBLISH_PATH = os.path.join(OLD_DOCKER_V1_PUBLISH_PATH, 'v1')
+
+
+def migrate():
+    """
+    Move all files and directories from /var/lib/pulp/published/docker/ to
+    /var/lib/pulp/published/docker/v1/.
+    """
+    misc.mkdir(NEW_DOCKER_V1_PUBLISH_PATH)
+
+    for folder in os.listdir(OLD_DOCKER_V1_PUBLISH_PATH):
+        if folder == 'v1':
+            continue
+        folder = os.path.join(OLD_DOCKER_V1_PUBLISH_PATH, folder)
+        if os.path.exists(folder):
+            shutil.move(folder, NEW_DOCKER_V1_PUBLISH_PATH)
+
+    # Now we must look for and repair broken symlinks
+    _repair_links()
+
+
+def _fix_link(path):
+    """
+    Adjust the link at path to reference the new publish path instead of the old publish path.
+
+    :param path: The path to the link that needs to be fixed
+    :type  path: basestring
+    """
+    link_target = os.readlink(path)
+    new_target = link_target.replace(OLD_DOCKER_V1_PUBLISH_PATH, NEW_DOCKER_V1_PUBLISH_PATH)
+    os.unlink(path)
+    os.symlink(new_target, path)
+
+
+def _link_broken(path):
+    """
+    Return True if the path is a broken symlink, False otherwise.
+
+    :param path: The path to be checked
+    :type  path: basestring
+    :return:     True if the path is a broken symlink, False otherwise
+    :rtype:      bool
+    """
+    if not os.path.islink(path):
+        # We only need to adjust symlinks, so we can move on
+        return False
+    link_target = os.readlink(path)
+    if link_target.startswith(NEW_DOCKER_V1_PUBLISH_PATH):
+        # This link is already adjusted to point to the new v1 location, so we don't need to
+        # do anything
+        return False
+    if link_target.startswith(OLD_DOCKER_V1_PUBLISH_PATH):
+        return True
+    return False
+
+
+def _repair_links():
+    """
+    Walk the directory tree, looking for symlinks to /var/lib/pulp/published/docker instead of
+    /var/lib/pulp/published/docker/v1 and fix them.
+    """
+    for dirpath, dirnames, filenames in os.walk(NEW_DOCKER_V1_PUBLISH_PATH):
+        for dirname in dirnames:
+            full_path = os.path.join(dirpath, dirname)
+            if _link_broken(full_path):
+                _fix_link(full_path)
+        for filename in filenames:
+            full_path = os.path.join(dirpath, filename)
+            if _link_broken(full_path):
+                _fix_link(full_path)

--- a/plugins/setup.py
+++ b/plugins/setup.py
@@ -16,6 +16,9 @@ setup(
         'pulp.distributors': [
             'web_distributor = pulp_docker.plugins.distributors.distributor_web:entry_point',
             'export_distributor = pulp_docker.plugins.distributors.distributor_export:entry_point',
+        ],
+        'pulp.server.db.migrations': [
+            'pulp_docker = pulp_docker.plugins.migrations'
         ]
     }
 )

--- a/plugins/test/unit/plugins/importers/test_v1_sync.py
+++ b/plugins/test/unit/plugins/importers/test_v1_sync.py
@@ -37,7 +37,7 @@ class TestGetLocalImagesStep(unittest.TestCase):
 
         self.assertTrue(unit is step.conduit.init_unit.return_value)
         step.conduit.init_unit.assert_called_once_with(
-            models.Image.TYPE_ID, {'image_id': 'abc123'}, {}, 'abc123')
+            models.Image.TYPE_ID, {'image_id': 'abc123'}, {}, 'docker_image/abc123')
 
 
 class TestSyncStep(unittest.TestCase):


### PR DESCRIPTION
This commit includes a migration that allows users to migrate from
pulp-docker-1.x to pulp-docker-2.0.0.

https://pulp.plan.io/issues/1217

re #1217