### PR TITLE
Have each step use its own space inside the working_dir.

### DIFF
--- a/plugins/pulp_docker/plugins/distributors/publish_steps.py
+++ b/plugins/pulp_docker/plugins/distributors/publish_steps.py
@@ -61,6 +61,8 @@ class V2WebPublisher(publish_step.PublishStep):
         app_file = configuration.get_redirect_file_name(repo)
         app_publish_location = os.path.join(
             configuration.get_app_publish_dir(config, docker_api_version), app_file)
+        self.working_dir = os.path.join(self.get_working_dir(), docker_api_version)
+        misc.mkdir(self.working_dir)
         self.web_working_dir = os.path.join(self.get_working_dir(), 'web')
         master_publish_dir = configuration.get_master_publish_dir(repo, config, docker_api_version)
         atomic_publish_step = publish_step.AtomicDirectoryPublishStep(
@@ -106,7 +108,7 @@ class PublishBlobsStep(publish_step.UnitPublishStep):
         :return: The path to where blobs should be published.
         :rtype:  basestring
         """
-        return os.path.join(self.get_working_dir(), 'blobs')
+        return os.path.join(self.parent.get_working_dir(), 'blobs')
 
 
 class PublishManifestsStep(publish_step.UnitPublishStep):
@@ -149,7 +151,7 @@ class PublishManifestsStep(publish_step.UnitPublishStep):
         :return: The path to where Manifests should be published.
         :rtype:  basestring
         """
-        return os.path.join(self.get_working_dir(), 'manifests')
+        return os.path.join(self.parent.get_working_dir(), 'manifests')
 
 
 class PublishTagsStep(publish_step.PublishStep):
@@ -172,7 +174,7 @@ class PublishTagsStep(publish_step.PublishStep):
         :param unit: The unit to process
         :type unit:  pulp_docker.common.models.Tag
         """
-        tags_path = os.path.join(self.get_working_dir(), 'tags')
+        tags_path = os.path.join(self.parent.get_working_dir(), 'tags')
         misc.mkdir(tags_path)
         with open(os.path.join(tags_path, 'list'), 'w') as list_file:
             list_file.write(json.dumps(list(self.parent.tags)))

--- a/plugins/pulp_docker/plugins/distributors/v1_publish_steps.py
+++ b/plugins/pulp_docker/plugins/distributors/v1_publish_steps.py
@@ -1,6 +1,7 @@
 from gettext import gettext as _
 import os
 
+from pulp.plugins.util import misc
 from pulp.plugins.util.publish_step import PublishStep, UnitPublishStep, \
     AtomicDirectoryPublishStep, SaveTarFilePublishStep
 
@@ -32,6 +33,8 @@ class WebPublisher(PublishStep):
         app_file = configuration.get_redirect_file_name(repo)
         app_publish_location = os.path.join(
             configuration.get_app_publish_dir(config, docker_api_version), app_file)
+        self.working_dir = os.path.join(self.get_working_dir(), docker_api_version)
+        misc.mkdir(self.working_dir)
         self.web_working_dir = os.path.join(self.get_working_dir(), 'web')
         master_publish_dir = configuration.get_master_publish_dir(repo, config, docker_api_version)
         atomic_publish_step = AtomicDirectoryPublishStep(self.get_working_dir(),
@@ -83,7 +86,7 @@ class PublishImagesStep(UnitPublishStep):
         """
         Initialize the metadata contexts
         """
-        self.redirect_context = RedirectFileContext(self.get_working_dir(),
+        self.redirect_context = RedirectFileContext(self.parent.get_working_dir(),
                                                     self.get_conduit(),
                                                     self.parent.config,
                                                     self.get_repo())
@@ -114,4 +117,4 @@ class PublishImagesStep(UnitPublishStep):
         """
         Get the directory where the files published to the web have been linked
         """
-        return os.path.join(self.get_working_dir(), 'web')
+        return os.path.join(self.parent.get_working_dir(), 'web')

--- a/plugins/test/unit/plugins/distributors/test_v1_publish_steps.py
+++ b/plugins/test/unit/plugins/distributors/test_v1_publish_steps.py
@@ -49,10 +49,12 @@ class TestPublishImagesStep(unittest.TestCase):
             touch(os.path.join(self.content_directory, file_name))
         unit = Mock(unit_key={'image_id': 'foo_image'}, storage_path=self.content_directory)
         step.get_working_dir = Mock(return_value=self.publish_directory)
+
         step.process_unit(unit)
+
         step.redirect_context.add_unit_metadata.assert_called_once_with(unit)
         for file_name in file_list:
-            self.assertTrue(os.path.exists(os.path.join(self.publish_directory, 'web',
+            self.assertTrue(os.path.exists(os.path.join(self.working_directory, 'web',
                                                         'foo_image', file_name)))
 
     def test_finalize(self):
@@ -102,7 +104,9 @@ class TestExportPublisher(unittest.TestCase):
         mock_config = {
             constants.CONFIG_KEY_DOCKER_PUBLISH_DIRECTORY: self.publish_dir
         }
+
         publisher = v1_publish_steps.ExportPublisher(self.repo, mock_conduit, mock_config)
+
         self.assertTrue(isinstance(publisher.children[0], v1_publish_steps.PublishImagesStep))
         self.assertTrue(isinstance(publisher.children[1], v1_publish_steps.SaveTarFilePublishStep))
         tar_step = publisher.children[1]


### PR DESCRIPTION
This commit makes each of the top level (v1 and v2) steps have their own separate working space, so that they do not
share files during the atomic publish.

https://pulp.plan.io/issues/1241

fixes #1241