### PR TITLE
Reconfigure the httpd vhost to better suit the Docker client.

### DIFF
--- a/plugins/etc/httpd/conf.d/pulp_docker.conf
+++ b/plugins/etc/httpd/conf.d/pulp_docker.conf
@@ -4,24 +4,21 @@
 
 # -- HTTPS Repositories ---------
 
+# This prevents mod_mime_magic from adding content-type and content-encoding headers, which will confuse the Docker
+# client.
+MimeMagicFile NEVER_EVER_USE
+
 # Docker v2
 Alias /pulp/docker/v2 /var/www/pub/docker/v2/web
-
 <Directory /var/www/pub/docker/v2/web>
+    Header set Docker-Distribution-API-Version "registry/2.0"
     SSLRequireSSL
-    SSLVerifyClient optional_no_ca
-    SSLVerifyDepth 2
-    SSLOptions +StdEnvVars +ExportCertData +FakeBasicAuth
     Options FollowSymlinks Indexes
 </Directory>
 
 # Docker v1
 Alias /pulp/docker/v1 /var/www/pub/docker/v1/web
-
 <Directory /var/www/pub/docker/v1/web>
     SSLRequireSSL
-    SSLVerifyClient optional_no_ca
-    SSLVerifyDepth 2
-    SSLOptions +StdEnvVars +ExportCertData +FakeBasicAuth
     Options FollowSymLinks Indexes
 </Directory>


### PR DESCRIPTION
This commit fixes a few issues with the httpd configuration for Docker v2:

* Docker is written in Go and thus it suffers from this bug:

    https://github.com/golang/go/issues/5742

  This commit removes most SSL directives from the httpd configuration because they were causing httpd to want to
  renegotiate with the client (causing the issue), and they were unnecessary to begin with. The SSL options in the
  config did not make much sense. They did things like exporting the client certificate into the environment, when
  this config only serves flat files. It also had strange client certificate settings when client certificates are
  not required for these views.
* The default httpd configuration in Fedora uses mod_mime_magic, which adds content-type and content-encoding
  headers to the responses. These headers confuse the Docker client, so this commit configures httpd not to do that
  for these paths.
* The Docker client expects to see the Docker-Distribution-API-Version set to registry/2.0 on all requests.

https://pulp.plan.io/issues/1256

fixes #1256