### PR TITLE
Form the redirect URL using the Docker API version.

### DIFF
--- a/plugins/pulp_docker/plugins/distributors/configuration.py
+++ b/plugins/pulp_docker/plugins/distributors/configuration.py
@@ -143,15 +143,18 @@ def get_redirect_file_name(repo):
     return '%s.json' % repo.id
 
 
-def get_redirect_url(config, repo):
+def get_redirect_url(config, repo, docker_api_version):
     """
     Get the redirect URL for a given repo & configuration
 
-    :param config: configuration instance for the repository
-    :type  config: pulp.plugins.config.PluginCallConfiguration or dict
-    :param repo: repository to get url for
-    :type  repo: pulp.plugins.model.Repository
-
+    :param config:             configuration instance for the repository
+    :type  config:             pulp.plugins.config.PluginCallConfiguration or dict
+    :param repo:               repository to get url for
+    :type  repo:               pulp.plugins.model.Repository
+    :param docker_api_version: The Docker API version that is being published ('v1' or 'v2')
+    :type  docker_api_version: basestring
+    :return:                   The redirect URL for the given config, repo, and Docker version
+    :rtype:                    basestring
     """
     redirect_url = config.get(constants.CONFIG_KEY_REDIRECT_URL)
     if redirect_url:
@@ -160,7 +163,7 @@ def get_redirect_url(config, repo):
     else:
         # build the redirect URL from the server config
         server_name = server_config.get('server', 'server_name')
-        redirect_url = 'https://%s/pulp/docker/%s/' % (server_name, repo.id)
+        redirect_url = 'https://%s/pulp/docker/%s/%s/' % (server_name, docker_api_version, repo.id)
 
     return redirect_url
 

--- a/plugins/pulp_docker/plugins/distributors/metadata.py
+++ b/plugins/pulp_docker/plugins/distributors/metadata.py
@@ -35,7 +35,7 @@ class RedirectFileContext(JSONArrayFileContext):
 
         self.registry = configuration.get_repo_registry_id(repo, config)
 
-        self.redirect_url = configuration.get_redirect_url(config, repo)
+        self.redirect_url = configuration.get_redirect_url(config, repo, 'v1')
         if config.get('protected', False):
             self.protected = "true"
         else:

--- a/plugins/pulp_docker/plugins/distributors/publish_steps.py
+++ b/plugins/pulp_docker/plugins/distributors/publish_steps.py
@@ -204,7 +204,7 @@ class RedirectFileStep(publish_step.PublishStep):
         Publish the JSON file for Crane.
         """
         registry = configuration.get_repo_registry_id(self.get_repo(), self.get_config())
-        redirect_url = configuration.get_redirect_url(self.get_config(), self.get_repo())
+        redirect_url = configuration.get_redirect_url(self.get_config(), self.get_repo(), 'v2')
 
         redirect_data = {
             'type': 'pulp-docker-redirect', 'version': 2, 'repository': self.get_repo().id,

--- a/plugins/test/unit/plugins/distributors/test_configuration.py
+++ b/plugins/test/unit/plugins/distributors/test_configuration.py
@@ -197,22 +197,22 @@ class TestConfigurationGetters(unittest.TestCase):
         sample_url = 'http://www.pulpproject.org/'
         conduit = Mock(repo_id=sample_url)
         url = configuration.get_redirect_url({constants.CONFIG_KEY_REDIRECT_URL: sample_url},
-                                             conduit)
+                                             conduit, 'v1')
         self.assertEquals(sample_url, url)
 
     def test_get_redirect_url_from_config_trailing_slash(self):
         sample_url = 'http://www.pulpproject.org'
         conduit = Mock(repo_id=sample_url)
         url = configuration.get_redirect_url({constants.CONFIG_KEY_REDIRECT_URL: sample_url},
-                                             conduit)
+                                             conduit, 'v1')
         self.assertEquals(sample_url + '/', url)
 
     @patch('pulp_docker.plugins.distributors.configuration.server_config')
     def test_get_redirect_url_generated(self, mock_server_config):
         mock_server_config.get.return_value = 'www.foo.bar'
-        computed_result = 'https://www.foo.bar/pulp/docker/baz/'
+        computed_result = 'https://www.foo.bar/pulp/docker/v1/baz/'
         self.assertEquals(computed_result, configuration.get_redirect_url({},
-                                                                          Mock(id='baz')))
+                                                                          Mock(id='baz'), 'v1'))
 
     def test_get_export_repo_filename(self):
         filename = configuration.get_export_repo_filename(self.repo, self.config)


### PR DESCRIPTION
The redirect URLs generated by the distributor did not include the Docker API version, which would lead to 404s. This
commit adds the Docker API version to the URLs.

https://pulp.plan.io/issues/1265

fixes #1265