### PR TITLE
passing new-style Repo object to controllers & saving before import_content

### DIFF
--- a/plugins/pulp_docker/plugins/importers/importer.py
+++ b/plugins/pulp_docker/plugins/importers/importer.py
@@ -76,7 +76,6 @@ class DockerImporter(Importer):
         :return: report of the details of the sync
         :rtype:  pulp.plugins.model.SyncReport
         """
-        repo = model.Repository.objects.get_repo_or_missing_resource(repo.id)
         try:
             # This will raise NotImplementedError if the config's feed_url is determined not to
             # support the Docker v2 API.

--- a/plugins/pulp_docker/plugins/importers/sync.py
+++ b/plugins/pulp_docker/plugins/importers/sync.py
@@ -181,7 +181,7 @@ class SaveUnitsStep(publish_step.SaveUnitsStep):
         :param item: The Unit to save in Pulp.
         :type  item: pulp.server.db.model.FileContentUnit
         """
+        item.save()
         item.set_storage_path(item.digest)
         item.import_content(os.path.join(self.get_working_dir(), item.digest))
-        item.save()
-        repository.associate_single_unit(self.get_repo(), item)
+        repository.associate_single_unit(self.get_repo().repo_obj, item)

--- a/plugins/pulp_docker/plugins/importers/v1_sync.py
+++ b/plugins/pulp_docker/plugins/importers/v1_sync.py
@@ -242,12 +242,12 @@ class SaveImages(SaveUnitsStep):
         item.size = size
 
         tmp_dir = os.path.join(self.get_working_dir(), item.image_id)
+        item.save()
         for name in os.listdir(tmp_dir):
             path = os.path.join(tmp_dir, name)
             item.import_content(path, location=os.path.basename(path))
 
-        item.save()
-        repo_controller.associate_single_unit(self.get_repo(), item)
+        repo_controller.associate_single_unit(self.get_repo().repo_obj, item)
 
     def finalize(self):
         """
@@ -256,7 +256,7 @@ class SaveImages(SaveUnitsStep):
         """
         super(SaveImages, self).finalize()
         # Get an updated copy of the repo so that we can update the tags
-        repo = self.get_repo()
+        repo = self.get_repo().repo_obj
         _logger.debug('updating tags for repo {repo_id}'.format(repo_id=repo.repo_id))
         if self.parent.tags:
             new_tags = tags.generate_updated_tags(repo.scratchpad, self.parent.tags)

--- a/plugins/test/unit/plugins/importers/test_sync.py
+++ b/plugins/test/unit/plugins/importers/test_sync.py
@@ -224,7 +224,7 @@ class TestSaveUnitsStep(unittest.TestCase):
             unit.import_content.assert_called_once_with(os.path.join('/some/path', unit.digest))
             unit.save.assert_called_once_with()
             self.assertEqual(associate_single_unit.mock_calls[-1][1][0],
-                             step.parent.get_repo.return_value)
+                             step.parent.get_repo.return_value.repo_obj)
             self.assertEqual(associate_single_unit.mock_calls[-1][1][1], unit)
 
     @mock.patch('pulp_docker.plugins.importers.sync.repository.associate_single_unit')
@@ -260,7 +260,7 @@ class TestSaveUnitsStep(unittest.TestCase):
             unit.import_content.assert_called_once_with(os.path.join(working_dir, unit.digest))
             unit.save.assert_called_once_with()
             self.assertEqual(associate_single_unit.mock_calls[-1][1][0],
-                             step.parent.get_repo.return_value)
+                             step.parent.get_repo.return_value.repo_obj)
             self.assertEqual(associate_single_unit.mock_calls[-1][1][1], unit)
 
     @mock.patch('pulp_docker.plugins.importers.sync.repository.associate_single_unit')


### PR DESCRIPTION
https://pulp.plan.io/issues/1453

I tested sync and publish with v1 and v2 registries.

Should be merged after:
https://github.com/pulp/pulp/pull/2291
https://github.com/pulp/pulp/pull/2289