### PR TITLE
Can sync v1 and v2 APIs together, and optionally disable v1 sync

### DIFF
--- a/common/pulp_docker/common/constants.py
+++ b/common/pulp_docker/common/constants.py
@@ -27,12 +27,16 @@ CONFIG_KEY_REPO_REGISTRY_ID = 'repo-registry-id'
 
 # Config keys for an importer override config
 CONFIG_KEY_MASK_ID = 'mask_id'
+CONFIG_KEY_ENABLE_V1 = 'enable_v1'
 
 SYNC_STEP_MAIN = 'sync_step_main'
 SYNC_STEP_METADATA = 'sync_step_metadata'
-SYNC_STEP_GET_LOCAL = 'sync_step_metadata'
 SYNC_STEP_DOWNLOAD = 'sync_step_download'
 SYNC_STEP_SAVE = 'sync_step_save'
+SYNC_STEP_SAVE_V1 = 'v1_sync_step_save'
+SYNC_STEP_METADATA_V1 = 'v1_sync_step_metadata'
+SYNC_STEP_GET_LOCAL_V1 = 'v1_sync_step_get_local'
+SYNC_STEP_DOWNLOAD_V1 = 'v1_sync_step_download'
 
 UPLOAD_STEP = 'upload_units_step'
 UPLOAD_STEP_METADATA = 'upload_step_metadata'

--- a/common/pulp_docker/common/error_codes.py
+++ b/common/pulp_docker/common/error_codes.py
@@ -21,3 +21,4 @@ DKR1006 = Error("DKR1006", _(
     ['field', 'value'])
 DKR1007 = Error("DKR1007", _("Could not fetch repository %(repo)s from registry %(registry)s"),
                 ['repo', 'registry'])
+DKR1008 = Error("DKR1008", _("Could not find registry API at %(registry)s"), ['registry'])

--- a/docs/tech-reference/importer.rst
+++ b/docs/tech-reference/importer.rst
@@ -8,13 +8,16 @@ Configuration
 
 The following options are available to the docker importer configuration.
 
+``enable_v1``
+ Boolean to control whether to attempt using registry API v1. Default is True.
+
+``feed``
+ The URL for the docker repository to import images from
+
 ``mask_id``
  Supported only as an override config option to a repository upload command, when
  this option is used, the upload command will skip adding given image and
  any ancestors of that image to the repository.
-
-``feed``
- The URL for the docker repository to import images from
 
 ``upstream_name``
  The name of the repository to import from the upstream repository

--- a/extensions_admin/pulp_docker/extensions/admin/cudl.py
+++ b/extensions_admin/pulp_docker/extensions/admin/cudl.py
@@ -45,6 +45,11 @@ OPTION_REMOVE_TAG = PulpCliOption('--remove-tag', d, required=False, allow_multi
 d = _('name of the upstream repository')
 OPT_UPSTREAM_NAME = PulpCliOption('--upstream-name', d, required=False)
 
+d = _('Enable sync of v1 API. defaults to "true"')
+OPT_ENABLE_V1 = PulpCliOption('--enable-v1', d, required=False,
+                              parse_func=okaara_parsers.parse_boolean)
+
+
 DESC_FEED = _('URL for the upstream docker index, not including repo name')
 
 
@@ -60,6 +65,7 @@ class CreateDockerRepositoryCommand(CreateAndConfigureRepositoryCommand, Importe
         self.add_option(OPT_REDIRECT_URL)
         self.add_option(OPT_PROTECTED)
         self.add_option(OPT_REPO_REGISTRY_ID)
+        self.add_option(OPT_ENABLE_V1)
         self.sync_group.add_option(OPT_UPSTREAM_NAME)
         self.options_bundle.opt_feed.description = DESC_FEED
 
@@ -118,6 +124,9 @@ class CreateDockerRepositoryCommand(CreateAndConfigureRepositoryCommand, Importe
         name = user_input.pop(OPT_UPSTREAM_NAME.keyword)
         if name is not None:
             config[constants.CONFIG_KEY_UPSTREAM_NAME] = name
+        enable_v1 = user_input.pop(OPT_ENABLE_V1.keyword)
+        if enable_v1 is not None:
+            config[constants.CONFIG_KEY_ENABLE_V1] = enable_v1
 
         return config
 
@@ -134,6 +143,7 @@ class UpdateDockerRepositoryCommand(UpdateRepositoryCommand, ImporterConfigMixin
         self.add_option(OPT_REDIRECT_URL)
         self.add_option(OPT_PROTECTED)
         self.add_option(OPT_REPO_REGISTRY_ID)
+        self.add_option(OPT_ENABLE_V1)
         self.sync_group.add_option(OPT_UPSTREAM_NAME)
         self.options_bundle.opt_feed.description = DESC_FEED
 

--- a/extensions_admin/test/unit/extensions/admin/test_cudl.py
+++ b/extensions_admin/test/unit/extensions/admin/test_cudl.py
@@ -46,9 +46,20 @@ class TestCreateDockerRepositoryCommand(unittest.TestCase):
         command = cudl.CreateDockerRepositoryCommand(Mock())
         user_input = {
             cudl.OPT_UPSTREAM_NAME.keyword: 'pulp/crane',
+            cudl.OPT_ENABLE_V1.keyword: None,
         }
         result = command._parse_importer_config(user_input)
         self.assertEqual(result[constants.CONFIG_KEY_UPSTREAM_NAME], 'pulp/crane')
+        self.assertTrue(constants.CONFIG_KEY_ENABLE_V1 not in result.keys())
+
+    def test_parse_importer_config_enable_v1_false(self):
+        command = cudl.CreateDockerRepositoryCommand(Mock())
+        user_input = {
+            cudl.OPT_UPSTREAM_NAME.keyword: 'pulp/crane',
+            cudl.OPT_ENABLE_V1.keyword: False,
+        }
+        result = command._parse_importer_config(user_input)
+        self.assertEqual(result[constants.CONFIG_KEY_ENABLE_V1], False)
 
 
 class TestUpdateDockerRepositoryCommand(unittest.TestCase):

--- a/plugins/pulp_docker/plugins/importers/importer.py
+++ b/plugins/pulp_docker/plugins/importers/importer.py
@@ -8,7 +8,7 @@ from pulp.server.db.model.criteria import UnitAssociationCriteria
 import pulp.server.managers.factory as manager_factory
 
 from pulp_docker.common import constants
-from pulp_docker.plugins.importers import sync, upload, v1_sync
+from pulp_docker.plugins.importers import sync, upload
 
 
 _logger = logging.getLogger(__name__)
@@ -76,14 +76,7 @@ class DockerImporter(Importer):
         :return: report of the details of the sync
         :rtype:  pulp.plugins.model.SyncReport
         """
-        try:
-            # This will raise NotImplementedError if the config's feed_url is determined not to
-            # support the Docker v2 API.
-            self.sync_step = sync.SyncStep(repo=repo, conduit=sync_conduit, config=config)
-        except NotImplementedError:
-            # Since the feed_url was determined not to support the Docker v2 API, let's use the
-            # old v1 SyncStep instead.
-            self.sync_step = v1_sync.SyncStep(repo=repo, conduit=sync_conduit, config=config)
+        self.sync_step = sync.SyncStep(repo=repo, conduit=sync_conduit, config=config)
 
         return self.sync_step.process_lifecycle()
 

--- a/plugins/pulp_docker/plugins/registry.py
+++ b/plugins/pulp_docker/plugins/registry.py
@@ -28,6 +28,7 @@ class V1Repository(object):
     DOCKER_ENDPOINT_HEADER = 'x-docker-endpoints'
     IMAGES_PATH = '/v1/repositories/%s/images'
     TAGS_PATH = '/v1/repositories/%s/tags'
+    API_VERSION_CHECK_PATH = '/v1/_ping'
 
     def __init__(self, name, download_config, registry_url, working_dir):
         """
@@ -106,6 +107,23 @@ class V1Repository(object):
         # this tells us what host to use when accessing image files
         if self.DOCKER_ENDPOINT_HEADER in headers:
             self.endpoint = headers[self.DOCKER_ENDPOINT_HEADER]
+
+    def api_version_check(self):
+        """
+        Make a call to the registry URL's /v1/_ping API call to determine if the registry supports
+        API v1.
+
+        :return: True if the v1 API is found, else False
+        :rtype:  bool
+        """
+        _logger.debug('Determining if the registry URL can do v1 of the Docker API.')
+
+        try:
+            self._get_single_path(self.API_VERSION_CHECK_PATH)
+        except IOError:
+            return False
+
+        return True
 
     def add_auth_header(self, request):
         """
@@ -278,26 +296,30 @@ class V2Repository(object):
     def api_version_check(self):
         """
         Make a call to the registry URL's /v2/ API call to determine if the registry supports API
-        v2. If it does not, raise NotImplementedError. If it does, return.
+        v2.
+
+        :return: True if the v2 API is found, else False
+        :rtype:  bool
         """
         _logger.debug('Determining if the registry URL can do v2 of the Docker API.')
-        exception = NotImplementedError('%s is not a Docker v2 registry.' % self.registry_url)
 
         try:
             headers, body = self._get_path(self.API_VERSION_CHECK_PATH)
         except IOError:
-            raise exception
+            return False
 
         try:
             version = headers['Docker-Distribution-API-Version']
             if version != "registry/2.0":
-                raise exception
+                return False
             _logger.debug(_('The docker registry is using API version: %(v)s') % {'v': version})
         except KeyError:
             # If the Docker-Distribution-API-Version header isn't present, we will assume that this
             # is a valid Docker 2.0 API server so that simple file-based webservers can serve as our
             # remote feed.
             pass
+
+        return True
 
     def create_blob_download_request(self, digest):
         """


### PR DESCRIPTION
fixes #1449
https://pulp.plan.io/issues/1449

I combined the root v1 and v2 sync steps into one. The step system requires a
single root step, and only one layer of children can report status and
progress. This required the refactor, combining each collection of steps onto
one parent.