### PR TITLE
Ensure file objects are cleaned up on error

### DIFF
--- a/plugins/pulp_docker/plugins/importers/sync.py
+++ b/plugins/pulp_docker/plugins/importers/sync.py
@@ -269,9 +269,8 @@ class SaveUnitsStep(publish_step.SaveUnitsStep):
         :param item: The Unit to save in Pulp.
         :type  item: pulp.server.db.model.FileContentUnit
         """
-        item.save()
         item.set_storage_path(item.digest)
-        item.import_content(os.path.join(self.get_working_dir(), item.digest))
+        item.save_and_import_content(os.path.join(self.get_working_dir(), item.digest))
         repository.associate_single_unit(self.get_repo().repo_obj, item)
 
 

--- a/plugins/pulp_docker/plugins/importers/v1_sync.py
+++ b/plugins/pulp_docker/plugins/importers/v1_sync.py
@@ -150,7 +150,7 @@ class SaveImages(SaveUnitsStep):
         item.save()
         for name in os.listdir(tmp_dir):
             path = os.path.join(tmp_dir, name)
-            item.import_content(path, location=os.path.basename(path))
+            item.safe_import_content(path, location=os.path.basename(path))
 
         repo_controller.associate_single_unit(self.get_repo().repo_obj, item)
 

--- a/plugins/test/unit/plugins/importers/test_sync.py
+++ b/plugins/test/unit/plugins/importers/test_sync.py
@@ -236,13 +236,11 @@ class TestSaveUnitsStep(unittest.TestCase):
         units = list(step.get_iterator())
 
         for unit in units:
-            unit.import_content = mock.MagicMock()
-            unit.save = mock.MagicMock()
+            unit.save_and_import_content = mock.MagicMock()
 
             step.process_main(item=unit)
-
-            unit.import_content.assert_called_once_with(os.path.join('/some/path', unit.digest))
-            unit.save.assert_called_once_with()
+            path = os.path.join('/some/path', unit.digest)
+            unit.save_and_import_content.assert_called_once_with(path)
             self.assertEqual(associate_single_unit.mock_calls[-1][1][0],
                              step.parent.get_repo.return_value.repo_obj)
             self.assertEqual(associate_single_unit.mock_calls[-1][1][1], unit)
@@ -272,13 +270,11 @@ class TestSaveUnitsStep(unittest.TestCase):
         units = list(step.get_iterator())
 
         for unit in units:
-            unit.import_content = mock.MagicMock()
-            unit.save = mock.MagicMock()
+            unit.save_and_import_content = mock.MagicMock()
 
             step.process_main(item=unit)
-
-            unit.import_content.assert_called_once_with(os.path.join(working_dir, unit.digest))
-            unit.save.assert_called_once_with()
+            path = os.path.join(working_dir, unit.digest)
+            unit.save_and_import_content.assert_called_once_with(path)
             self.assertEqual(associate_single_unit.mock_calls[-1][1][0],
                              step.parent.get_repo.return_value.repo_obj)
             self.assertEqual(associate_single_unit.mock_calls[-1][1][1], unit)
@@ -303,13 +299,12 @@ class TestSaveUnitsStep(unittest.TestCase):
         units = list(step.get_iterator())
 
         for unit in units:
-            unit.import_content = mock.MagicMock()
-            unit.save = mock.MagicMock()
+            unit.save_and_import_content = mock.MagicMock()
 
             step.process_main(item=unit)
 
-            unit.import_content.assert_called_once_with(os.path.join(working_dir, unit.digest))
-            unit.save.assert_called_once_with()
+            path = os.path.join(working_dir, unit.digest)
+            unit.save_and_import_content.assert_called_once_with(path)
             self.assertEqual(associate_single_unit.mock_calls[-1][1][0],
                              step.parent.get_repo.return_value)
             self.assertEqual(associate_single_unit.mock_calls[-1][1][1], unit)


### PR DESCRIPTION
Call save_and_import_content().

Utilize cleanup pattern instead where usage doesn't
fit.

re #[1457](https://pulp.plan.io/issues/1457)
https://pulp.plan.io/issues/1457