### PR TITLE
Sync v1 and v2 content when the registry support it.

### DIFF
--- a/plugins/pulp_docker/plugins/importers/importer.py
+++ b/plugins/pulp_docker/plugins/importers/importer.py
@@ -10,7 +10,7 @@ import pulp.server.managers.factory as manager_factory
 
 from pulp_docker.common import constants, tarutils
 from pulp_docker.common.models import Image, Manifest, Blob
-from pulp_docker.plugins.importers import sync, upload, v1_sync
+from pulp_docker.plugins.importers import sync, upload
 
 
 _logger = logging.getLogger(__name__)
@@ -80,19 +80,9 @@ class DockerImporter(Importer):
         """
         working_dir = tempfile.mkdtemp(dir=repo.working_dir)
         try:
-            try:
-                # This will raise NotImplementedError if the config's feed_url is determined not to
-                # support the Docker v2 API.
-                self.sync_step = sync.SyncStep(repo=repo, conduit=sync_conduit, config=config,
-                                               working_dir=working_dir)
-            except NotImplementedError:
-                # Since the feed_url was determined not to support the Docker v2 API, let's use the
-                # old v1 SyncStep instead.
-                self.sync_step = v1_sync.SyncStep(repo=repo, conduit=sync_conduit, config=config,
-                                                  working_dir=working_dir)
-
+            self.sync_step = sync.SyncStep(repo=repo, conduit=sync_conduit, config=config,
+                                           working_dir=working_dir)
             return self.sync_step.sync()
-
         finally:
             shutil.rmtree(working_dir, ignore_errors=True)
 

--- a/plugins/test/unit/plugins/importers/test_importer.py
+++ b/plugins/test/unit/plugins/importers/test_importer.py
@@ -65,21 +65,6 @@ class TestSyncRepo(unittest.TestCase):
 
         mock_sync_step.return_value.sync.assert_called_once_with()
 
-    @mock.patch('pulp_docker.plugins.importers.v1_sync.SyncStep')
-    def test_fall_back_to_v1(self, v1_sync_step, mock_rmtree, mock_mkdtemp, mock_sync_step):
-        """
-        Ensure that the sync_repo() method falls back to Docker v1 if Docker v2 isn't available.
-        """
-        # Simulate the v2 API being unavailable
-        mock_sync_step.side_effect = NotImplementedError()
-
-        self.importer.sync_repo(self.repo, self.sync_conduit, self.config)
-
-        v1_sync_step.assert_called_once_with(
-            repo=self.repo, conduit=self.sync_conduit, config=self.config,
-            working_dir=mock_mkdtemp.return_value)
-        v1_sync_step.return_value.sync.assert_called_once_with()
-
     def test_makes_temp_dir(self, mock_rmtree, mock_mkdtemp, mock_sync_step):
         self.importer.sync_repo(self.repo, self.sync_conduit, self.config)
 

--- a/plugins/test/unit/plugins/test_registry.py
+++ b/plugins/test/unit/plugins/test_registry.py
@@ -372,7 +372,7 @@ class TestV2Repository(unittest.TestCase):
         r = registry.V2Repository(name, download_config, registry_url, working_dir)
         r.downloader.download_one = mock.MagicMock(side_effect=download_one)
 
-        self.assertRaises(NotImplementedError, r.api_version_check)
+        self.assertEqual(r.api_version_check(), False)
 
     def test_api_version_check_ioerror(self):
         """
@@ -384,8 +384,8 @@ class TestV2Repository(unittest.TestCase):
         working_dir = '/a/working/dir'
         r = registry.V2Repository(name, download_config, registry_url, working_dir)
 
-        # The IOError will be raised since registry_url isn't a real registry
-        self.assertRaises(NotImplementedError, r.api_version_check)
+        # False will be returned since registry_url isn't a real registry
+        self.assertEqual(r.api_version_check(), False)
 
     def test_api_version_check_missing_header(self):
         """


### PR DESCRIPTION
pulp-docker used to try v2 and fall back to v1 if v2 was not
supported. This commit causes pulp-docker to sync both for
registries that support them.

https://pulp.plan.io/issues/1449

re #1449