### PR TITLE
Make requests to docker registry with bearer tokens

### DIFF
--- a/plugins/pulp_docker/plugins/importers/sync.py
+++ b/plugins/pulp_docker/plugins/importers/sync.py
@@ -3,6 +3,7 @@ This module contains the primary sync entry point for Docker v2 registries.
 """
 from gettext import gettext as _
 import errno
+import httplib
 import itertools
 import logging
 import os
@@ -13,7 +14,7 @@ from pulp.server.controllers import repository
 from pulp.server.exceptions import MissingValue, PulpCodedException
 
 from pulp_docker.common import constants, error_codes
-from pulp_docker.plugins import models, registry
+from pulp_docker.plugins import models, registry, token_util
 from pulp_docker.plugins.importers import v1_sync
 
 
@@ -68,7 +69,7 @@ class SyncStep(publish_step.PluginStep):
 
         # determine which API versions are supported and add corresponding steps
         v2_found = self.index_repository.api_version_check()
-        v1_enabled = config.get(constants.CONFIG_KEY_ENABLE_V1, default=True)
+        v1_enabled = config.get(constants.CONFIG_KEY_ENABLE_V1, default=False)
         if not v1_enabled:
             _logger.debug(_('v1 API skipped due to config'))
         v1_found = v1_enabled and self.v1_index_repository.api_version_check()
@@ -104,7 +105,7 @@ class SyncStep(publish_step.PluginStep):
         self.add_child(self.step_get_local_manifests)
         self.add_child(self.step_get_local_blobs)
         self.add_child(
-            publish_step.DownloadStep(
+            TokenAuthDownloadStep(
                 step_type=constants.SYNC_STEP_DOWNLOAD, downloads=self.generate_download_requests(),
                 repo=self.repo, config=self.config, description=_('Downloading remote files')))
         self.add_child(SaveUnitsStep())
@@ -300,3 +301,54 @@ class SaveTagsStep(publish_step.SaveUnitsStep):
                                                       tag_name=tag, manifest_digest=manifest.digest)
             if new_tag:
                 repository.associate_single_unit(self.get_repo().repo_obj, new_tag)
+
+
+class TokenAuthDownloadStep(publish_step.DownloadStep):
+    """
+    Download remote files. For v2, this may require a bearer token to be used. This step attempts
+    to download files, and if it fails due to a 401, it will retrieve the auth token and retry the
+    download.
+    """
+
+    def __init__(self, step_type, downloads=None, repo=None, conduit=None, config=None,
+                 working_dir=None, plugin_type=None, description=''):
+        """
+        Initialize the step, setting its description.
+        """
+
+        super(TokenAuthDownloadStep, self).__init__(
+            step_type, downloads=downloads, repo=repo, conduit=conduit, config=config,
+            working_dir=working_dir, plugin_type=plugin_type)
+        self.description = _('Downloading remote files')
+        self.token = None
+        self._requests_map = {}
+
+    def process_main(self, item=None):
+        """
+        Overrides the parent method to get a new token and try again if response is a 401.
+        """
+        # Allow the original request to be retrieved from the url.
+        for request in self.downloads:
+            self._requests_map[request.url] = request
+
+        for request in self.downloads:
+            if self.token:
+                token_util.add_auth_header(request, self.token)
+            self.downloader.download_one(request, events=True)
+
+    def download_failed(self, report):
+        """
+        If the download fails due to a 401, attempt to retreive a token and try again.
+
+        :param report: download report
+        :type  report: nectar.report.DownloadReport
+        """
+        if report.error_report.get('response_code') == httplib.UNAUTHORIZED:
+            _logger.debug(_('Download unauthorized, attempting to retrieve a token.'))
+            request = self._requests_map[report.url]
+            token = token_util.request_token(self.downloader, request, report.headers)
+            token_util.add_auth_header(request, token)
+            _logger.debug("Trying download again with new bearer token.")
+            report = self.downloader.download_one(request)
+        if report.state == report.DOWNLOAD_FAILED:
+            super(TokenAuthDownloadStep, self).download_failed(report)

--- a/plugins/pulp_docker/plugins/token_util.py
+++ b/plugins/pulp_docker/plugins/token_util.py
@@ -1,0 +1,92 @@
+from cStringIO import StringIO
+import json
+import logging
+import urllib
+import urlparse
+
+from nectar.request import DownloadRequest
+
+
+_logger = logging.getLogger(__name__)
+
+
+def add_auth_header(request, token):
+    """
+    Adds the token into the request's headers as specified in the Docker v2 API documentation.
+
+    https://docs.docker.com/registry/spec/auth/token/#using-the-bearer-token
+
+    :param request: a download request
+    :type  request: nectar.request.DownloadRequest
+    :param token: a Bearer token to be inserted into the Authorization header
+    :type  token: basestring
+    """
+    if request.headers is None:
+        request.headers = {}
+    request.headers['Authorization'] = 'Bearer %s' % token
+
+
+def request_token(downloader, request, response_headers):
+    """
+    Attempts to retrieve the correct token based on the 401 response header.
+
+    According to the Docker API v2 documentation, the token be retrieved by issuing a GET
+    request to the url specified by the `realm` within the `WWW-Authenticate` header. This
+    request should add the following query parameters:
+
+        service: the name of the service that hosts the desired resource
+        scope:   the specific resource and permissions requested
+
+    https://docs.docker.com/registry/spec/auth/token/#requesting-a-token
+
+    :param downloader: Nectar downloader that will be used to issue a download request
+    :type  downloader: nectar.downloaders.threaded.HTTPThreadedDownloader
+    :param request: a download request
+    :type  request: nectar.request.DownloadRequest
+    :param response_headers: headers from the 401 response
+    :type  response_headers: basestring
+    :return: Bearer token for requested resource
+    :rtype:  str
+    """
+    auth_info = parse_401_response_headers(response_headers)
+    try:
+        token_url = auth_info.pop('realm')
+    except KeyError:
+        raise IOError("No realm specified for token auth challenge.")
+
+    parse_result = urlparse.urlparse(token_url)
+    query_dict = urlparse.parse_qs(parse_result.query)
+    query_dict.update(auth_info)
+    url_pieces = list(parse_result)
+    url_pieces[4] = urllib.urlencode(query_dict)
+    token_url = urlparse.urlunparse(url_pieces)
+
+    token_data = StringIO()
+    token_request = DownloadRequest(token_url, token_data)
+    _logger.debug("Requesting token from {url}".format(url=token_url))
+    report = downloader.download_one(token_request)
+    if report.state == report.DOWNLOAD_FAILED:
+        raise IOError(report.error_msg)
+
+    return json.loads(token_data.getvalue())['token']
+
+
+def parse_401_response_headers(response_headers):
+    """
+    Parse the headers from a 401 response into a dictionary that contains the information
+    necessary to retrieve a token.
+
+    :param response_headers: headers returned in a 401 response
+    :type  response_headers: requests.structures.CaseInsensitiveDict
+    """
+    auth_header = response_headers.get('www-authenticate')
+    if auth_header is None:
+        raise IOError("401 responses are expected to conatin authentication information")
+    auth_header = auth_header[len("Bearer "):]
+
+    # The remaining string consists of comma seperated key=value pairs
+    auth_dict = {}
+    for key, value in (item.split('=') for item in auth_header.split(',')):
+        # The value is a string within a string, ex: '"value"'
+        auth_dict[key] = json.loads(value)
+    return auth_dict

--- a/plugins/test/unit/plugins/importers/test_sync.py
+++ b/plugins/test/unit/plugins/importers/test_sync.py
@@ -373,7 +373,7 @@ class TestSyncStep(unittest.TestCase):
         self.assertEqual(
             [type(child) for child in step.children],
             [sync.DownloadManifestsStep, publish_step.GetLocalUnitsStep,
-             publish_step.GetLocalUnitsStep, publish_step.DownloadStep, sync.SaveUnitsStep,
+             publish_step.GetLocalUnitsStep, sync.TokenAuthDownloadStep, sync.SaveUnitsStep,
              sync.SaveTagsStep])
         # Ensure the first step was initialized correctly
         self.assertEqual(step.children[0].repo, repo)
@@ -400,6 +400,7 @@ class TestSyncStep(unittest.TestCase):
     def test_init_v1(self, mock_check_v1, mock_check_v2, mock_validate, _working_directory_path):
         _working_directory_path.return_value = self.working_dir
         # re-run this with the mock in place
+        self.config.override_config[constants.CONFIG_KEY_ENABLE_V1] = True
         step = sync.SyncStep(self.repo, self.conduit, self.config)
 
         self.assertEqual(step.step_id, constants.SYNC_STEP_MAIN)
@@ -501,6 +502,7 @@ class TestSyncStep(unittest.TestCase):
     @mock.patch('pulp.server.managers.repo._common._working_directory_path')
     def test_v1_generate_download_requests(self, mock_working_dir, mock_v1_check, mock_v2_check):
         mock_working_dir.return_value = tempfile.mkdtemp()
+        self.config.override_config[constants.CONFIG_KEY_ENABLE_V1] = True
         step = sync.SyncStep(self.repo, self.conduit, self.config)
         step.v1_step_get_local_units.units_to_download.append(models.Image(image_id='image1'))
 
@@ -522,6 +524,7 @@ class TestSyncStep(unittest.TestCase):
     def test_generate_download_requests_correct_urls(self, mock_working_dir, mock_v1_check,
                                                      mock_v2_check):
         mock_working_dir.return_value = tempfile.mkdtemp()
+        self.config.override_config[constants.CONFIG_KEY_ENABLE_V1] = True
         step = sync.SyncStep(self.repo, self.conduit, self.config)
         step.v1_step_get_local_units.units_to_download.append(models.Image(image_id='image1'))
 
@@ -542,6 +545,7 @@ class TestSyncStep(unittest.TestCase):
     def test_generate_download_requests_correct_destinations(self, mock_working_dir,
                                                              mock_v1_check, mock_v2_check):
         mock_working_dir.return_value = tempfile.mkdtemp()
+        self.config.override_config[constants.CONFIG_KEY_ENABLE_V1] = True
         step = sync.SyncStep(self.repo, self.conduit, self.config)
         step.v1_step_get_local_units.units_to_download.append(models.Image(image_id='image1'))
 
@@ -565,6 +569,7 @@ class TestSyncStep(unittest.TestCase):
     def test_generate_download_reqs_creates_dir(self, mock_working_dir, mock_v1_check,
                                                 mock_v2_check):
         mock_working_dir.return_value = tempfile.mkdtemp()
+        self.config.override_config[constants.CONFIG_KEY_ENABLE_V1] = True
         step = sync.SyncStep(self.repo, self.conduit, self.config)
         step.v1_step_get_local_units.units_to_download.append(models.Image(image_id='image1'))
 
@@ -582,6 +587,7 @@ class TestSyncStep(unittest.TestCase):
     def test_generate_download_reqs_existing_dir(self, mock_working_dir, mock_v1_check,
                                                  mock_v2_check):
         mock_working_dir.return_value = tempfile.mkdtemp()
+        self.config.override_config[constants.CONFIG_KEY_ENABLE_V1] = True
         step = sync.SyncStep(self.repo, self.conduit, self.config)
         step.v1_step_get_local_units.units_to_download.append(models.Image(image_id='image1'))
         os.makedirs(os.path.join(step.working_dir, 'image1'))
@@ -598,6 +604,7 @@ class TestSyncStep(unittest.TestCase):
     def test_generate_download_reqs_perm_denied(self, mock_working_dir, mock_v1_check,
                                                 mock_v2_check):
         mock_working_dir.return_value = tempfile.mkdtemp()
+        self.config.override_config[constants.CONFIG_KEY_ENABLE_V1] = True
         try:
             step = sync.SyncStep(self.repo, self.conduit, self.config)
             step.v1_step_get_local_units.units_to_download.append(models.Image(image_id='image1'))
@@ -614,6 +621,7 @@ class TestSyncStep(unittest.TestCase):
     def test_generate_download_reqs_ancestry_exists(self, mock_working_dir, mock_v1_check,
                                                     mock_v2_check):
         mock_working_dir.return_value = tempfile.mkdtemp()
+        self.config.override_config[constants.CONFIG_KEY_ENABLE_V1] = True
         step = sync.SyncStep(self.repo, self.conduit, self.config)
         step.v1_step_get_local_units.units_to_download.append(models.Image(image_id='image1'))
         os.makedirs(os.path.join(step.working_dir, 'image1'))

--- a/plugins/test/unit/plugins/test_token_util.py
+++ b/plugins/test/unit/plugins/test_token_util.py
@@ -1,0 +1,93 @@
+from pulp.common.compat import unittest
+import mock
+
+from pulp_docker.plugins import token_util
+
+
+class TestAddAuthHeader(unittest.TestCase):
+    """
+    Tests for adding a bearer token to a request header.
+    """
+
+    def test_no_headers(self):
+        """
+        Test that when there are no existing headers, it is added.
+        """
+        mock_req = mock.MagicMock()
+        mock_req.headers = None
+
+        token_util.add_auth_header(mock_req, "mock token")
+        self.assertDictEqual(mock_req.headers, {"Authorization": "Bearer mock token"})
+
+    def test_with_headers(self):
+        """
+        Test that when the headers exists, the auth token is added to it.
+        """
+        mock_req = mock.MagicMock()
+        mock_req.headers = {"mock": "header"}
+
+        token_util.add_auth_header(mock_req, "mock token")
+        self.assertDictEqual(mock_req.headers, {"Authorization": "Bearer mock token",
+                                                "mock": "header"})
+
+
+class TestRequestToken(unittest.TestCase):
+    """
+    Tests for the utility to request a token from the response headers of a 401.
+    """
+    @mock.patch('pulp_docker.plugins.token_util.parse_401_response_headers')
+    def test_no_realm(self, mock_parse):
+        """
+        When the realm is not specified, raise.
+        """
+        m_downloader = mock.MagicMock()
+        m_req = mock.MagicMock()
+        m_headers = mock.MagicMock()
+        resp_headers = {'missing': 'realm'}
+        mock_parse.return_value = resp_headers
+        self.assertRaises(IOError, token_util.request_token, m_downloader, m_req, m_headers)
+        mock_parse.assert_called_once_with(m_headers)
+
+    @mock.patch('pulp_docker.plugins.token_util.StringIO')
+    @mock.patch('pulp_docker.plugins.token_util.DownloadRequest')
+    @mock.patch('pulp_docker.plugins.token_util.urllib.urlencode')
+    @mock.patch('pulp_docker.plugins.token_util.parse_401_response_headers')
+    def test_as_expected(self, mock_parse, mock_encode, m_dl_req, m_string_io):
+        """
+        Test that a request is created with correct query parameters to retrieve a bearer token.
+        """
+        m_downloader = mock.MagicMock()
+        m_req = mock.MagicMock()
+        m_headers = mock.MagicMock()
+        m_string_io.return_value.getvalue.return_value = '{"token": "Hey, its a token!"}'
+        mock_parse.return_value = {'realm': 'url', 'other_info': 'stuff'}
+        mock_encode.return_value = 'other_info=stuff'
+        token_util.request_token(m_downloader, m_req, m_headers)
+
+        mock_encode.assert_called_once_with({'other_info': 'stuff'})
+        m_dl_req.assert_called_once_with('url?other_info=stuff', m_string_io.return_value)
+        mock_parse.assert_called_once_with(m_headers)
+        m_downloader.download_one.assert_called_once_with(m_dl_req.return_value)
+
+
+class TestParse401ResponseHeaders(unittest.TestCase):
+    """
+    Tests for parsing 401 headers.
+    """
+
+    def test_missing_header(self):
+        """
+        Raise if 401 does not include the header with authentication information.
+        """
+        headers = {'missing-www-auth': 'should fail'}
+        self.assertRaises(IOError, token_util.parse_401_response_headers, headers)
+
+    def test_dict_created(self):
+        """
+        Ensure that the www-authenticate header is correctly parsed into a dict.
+        """
+        headers = {'www-authenticate':
+                   'Bearer realm="https://auth.docker.io/token",service="registry.docker.io"'}
+        ret = token_util.parse_401_response_headers(headers)
+        self.assertDictEqual(ret, {"realm": "https://auth.docker.io/token",
+                                   "service": "registry.docker.io"})


### PR DESCRIPTION
closes: #1144

https://pulp.plan.io/issues/1596
https://pulp.plan.io/issues/1144

Note: This will hang indefinitely due to https://pulp.plan.io/issues/1567, so Nectar will need to be rebuilt for this to function correctly. @ipanova 