### PR TITLE
Add library namespace to docker hub images

### DIFF
--- a/plugins/pulp_docker/plugins/registry.py
+++ b/plugins/pulp_docker/plugins/registry.py
@@ -5,6 +5,7 @@ import httplib
 import json
 import logging
 import os
+import re
 import traceback
 import urlparse
 
@@ -289,7 +290,16 @@ class V2Repository(object):
                                 be saved
         :type  working_dir:     basestring
         """
-        self.name = name
+
+        # Docker's registry aligns non-namespaced images to the library namespace.
+        # if we have a docker registry image, and no namespace, add the library
+        # namespace to the image name.
+
+        if '/' not in name and re.search(r'registry[-,\w]*.docker.io', registry_url, re.IGNORECASE):
+            self.name = "library/" + name
+        else:
+            self.name = name
+
         self.download_config = download_config
         self.registry_url = registry_url
         self.downloader = HTTPThreadedDownloader(self.download_config, AggregatingEventListener())

--- a/plugins/test/unit/plugins/test_registry.py
+++ b/plugins/test/unit/plugins/test_registry.py
@@ -600,3 +600,42 @@ class TestV2Repository(unittest.TestCase):
 
         self.assertEqual(headers, {'some': 'cool stuff'})
         self.assertEqual(body, "This is the stuff you've been waiting for.")
+
+    @mock.patch('pulp_docker.plugins.registry.HTTPThreadedDownloader')
+    def test_dockerhub_v2_registry_without_namespace(self, http_threaded_downloader):
+        name = 'test_image'
+        registry_url = "https://registry-1.docker.io"
+        download_config = mock.MagicMock()
+        working_dir = '/a/working/dir'
+        r = registry.V2Repository(name, download_config, registry_url, working_dir)
+        self.assertEqual('library/test_image', r.name, "Non-name-spaced image not prepended")
+
+    @mock.patch('pulp_docker.plugins.registry.HTTPThreadedDownloader')
+    def test_dockerhub_v2_registry_with_namespace(self, http_threaded_downloader):
+        name = 'library/test_image'
+        registry_url = "https://registry-1.docker.io"
+        download_config = mock.MagicMock()
+        working_dir = '/a/working/dir'
+        r = registry.V2Repository(name, download_config, registry_url, working_dir)
+        self.assertNotEqual('library/library/test_image', r.name,
+                            "Name-spaced image prepended with library")
+
+    @mock.patch('pulp_docker.plugins.registry.HTTPThreadedDownloader')
+    def test_non_dockerhub_v2_registry_with_namespace(self, http_threaded_downloader):
+        name = 'library/test_image'
+        registry_url = "https://somewhere.not-docker.io"
+        download_config = mock.MagicMock()
+        working_dir = '/a/working/dir'
+        r = registry.V2Repository(name, download_config, registry_url, working_dir)
+        self.assertNotEqual('library/library/test_image', r.name,
+                            "Name-spaced Non-docker hub image prepended with library")
+
+    @mock.patch('pulp_docker.plugins.registry.HTTPThreadedDownloader')
+    def test_non_dockerhub_v2_registry_without_namespace(self, http_threaded_downloader):
+        name = 'test_image'
+        registry_url = "https://somewhere.not-docker.io"
+        download_config = mock.MagicMock()
+        working_dir = '/a/working/dir'
+        r = registry.V2Repository(name, download_config, registry_url, working_dir)
+        self.assertNotEqual('library/test_image', r.name,
+                            "Non-docker hub image prepended with library")


### PR DESCRIPTION
Add library namespace to docker hub registry images that do not
have one.

closes #1404
https://pulp.plan.io/issues/1404