### PR TITLE
Pass the old-style repo object to the UploadStep.

### DIFF
--- a/plugins/pulp_docker/plugins/importers/importer.py
+++ b/plugins/pulp_docker/plugins/importers/importer.py
@@ -4,7 +4,6 @@ import logging
 from pulp.common.config import read_json_config
 from pulp.plugins.importer import Importer
 from pulp.server.controllers import repository
-from pulp.server.db import model
 from pulp.server.db.model.criteria import UnitAssociationCriteria
 from pulp.server.managers.repo import unit_association
 import pulp.server.managers.factory as manager_factory
@@ -126,8 +125,6 @@ class DockerImporter(Importer):
                             'details':      json-serializable object, providing details
         :rtype:           dict
         """
-        repo = model.Repository.objects.get_repo_or_missing_resource(repo.id)
-
         upload_step = upload.UploadStep(repo=repo, file_path=file_path, config=config)
         upload_step.process_lifecycle()
 

--- a/plugins/test/unit/plugins/importers/test_importer.py
+++ b/plugins/test/unit/plugins/importers/test_importer.py
@@ -91,9 +91,8 @@ class TestUploadUnit(unittest.TestCase):
     """
     Assert correct operation of DockerImporter.upload_unit().
     """
-    @mock.patch('pulp_docker.plugins.importers.importer.model.Repository.objects')
     @mock.patch('pulp_docker.plugins.importers.importer.upload.UploadStep')
-    def test_correct_calls(self, UploadStep, objects):
+    def test_correct_calls(self, UploadStep):
         """
         Assert that upload_unit() builds the UploadStep correctly and calls its process_lifecycle()
         method.
@@ -106,9 +105,8 @@ class TestUploadUnit(unittest.TestCase):
         DockerImporter().upload_unit(repo, constants.IMAGE_TYPE_ID, unit_key,
                                      {}, data.busybox_tar_path, conduit, config)
 
-        objects.get_repo_or_missing_resource.assert_called_once_with(repo.id)
-        UploadStep.assert_called_once_with(repo=objects.get_repo_or_missing_resource.return_value,
-                                           file_path=data.busybox_tar_path, config=config)
+        UploadStep.assert_called_once_with(repo=repo, file_path=data.busybox_tar_path,
+                                           config=config)
         UploadStep.return_value.process_lifecycle.assert_called_once_with()
 
 
@@ -299,7 +297,6 @@ class TestValidateConfig(unittest.TestCase):
             self.assertEqual(DockerImporter().validate_config(repo, config), (True, ''))
 
 
-@mock.patch('pulp_docker.plugins.importers.importer.model.Repository.objects')
 class TestRemoveUnits(unittest.TestCase):
 
     # We are under a significant time crunch and don't have time to correct all the tests with this
@@ -336,7 +333,6 @@ class TestRemoveUnits(unittest.TestCase):
         self.assertEqual(mock_repo.scratchpad['tags'], [])
 
 
-@mock.patch('pulp_docker.plugins.importers.importer.model.Repository.objects')
 class TestPurgeUnreferencedTags(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
https://pulp.plan.io/issues/1648

fixes #1648