### PR TITLE
Manifest.digest static method was renamed

### DIFF
--- a/plugins/pulp_docker/plugins/registry.py
+++ b/plugins/pulp_docker/plugins/registry.py
@@ -376,7 +376,7 @@ class V2Repository(object):
                 msg = msg.format(e=expected_digest, d=digest)
                 raise IOError(msg)
         else:
-            digest = models.Manifest.digest(manifest)
+            digest = models.Manifest.calculate_digest(manifest)
         return digest, manifest
 
     def get_tags(self):


### PR DESCRIPTION
Static method Manifest.digest was renamed to Manfiest.calculate_digest 
in the mongoengine conversion

closes #1672
https://pulp.plan.io/issues/1672