### PR TITLE
Download docker blobs in parallel

### DIFF
--- a/plugins/pulp_docker/plugins/importers/sync.py
+++ b/plugins/pulp_docker/plugins/importers/sync.py
@@ -337,20 +337,15 @@ class TokenAuthDownloadStep(publish_step.DownloadStep):
 
     def process_main(self, item=None):
         """
-        Overrides the parent method to get a new token and try again if response is a 401.
+        Allow request objects to be available after a download fails.
         """
-        # Allow the original request to be retrieved from the url.
         for request in self.downloads:
             self._requests_map[request.url] = request
-
-        for request in self.downloads:
-            if self.token:
-                token_util.add_auth_header(request, self.token)
-            self.downloader.download_one(request, events=True)
+        super(TokenAuthDownloadStep).process_main(item)
 
     def download_failed(self, report):
         """
-        If the download fails due to a 401, attempt to retreive a token and try again.
+        If the download is unauthorized, attempt to retreive a token and try again.
 
         :param report: download report
         :type  report: nectar.report.DownloadReport
@@ -359,8 +354,12 @@ class TokenAuthDownloadStep(publish_step.DownloadStep):
             _logger.debug(_('Download unauthorized, attempting to retrieve a token.'))
             request = self._requests_map[report.url]
             token = token_util.request_token(self.downloader, request, report.headers)
-            token_util.add_auth_header(request, token)
+            self.downloader.session.headers = token_util.update_auth_header(
+                self.downloader.session.headers, token)
             _logger.debug("Trying download again with new bearer token.")
-            report = self.downloader.download_one(request, events=True)
-        if report.state == report.DOWNLOAD_FAILED:
+            # Events must be false or download_failed will recurse
+            report = self.downloader.download_one(request, events=False)
+        if report.state is report.DOWNLOAD_SUCCEEDED:
+            self.download_succeeded(report)
+        elif report.state is report.DOWNLOAD_FAILED:
             super(TokenAuthDownloadStep, self).download_failed(report)

--- a/plugins/pulp_docker/plugins/registry.py
+++ b/plugins/pulp_docker/plugins/registry.py
@@ -407,7 +407,7 @@ class V2Repository(object):
         request = DownloadRequest(url, StringIO())
 
         if self.token:
-            token_util.add_auth_header(request, self.token)
+            request.headers = token_util.update_auth_header(request.headers, self.token)
 
         report = self.downloader.download_one(request)
 
@@ -416,7 +416,7 @@ class V2Repository(object):
             if report.error_report.get('response_code') == httplib.UNAUTHORIZED:
                 _logger.debug(_('Download unauthorized, attempting to retrieve a token.'))
                 self.token = token_util.request_token(self.downloader, request, report.headers)
-                token_util.add_auth_header(request, self.token)
+                request.headers = token_util.update_auth_header(request.headers, self.token)
                 report = self.downloader.download_one(request)
 
         if report.state == report.DOWNLOAD_FAILED:

--- a/plugins/pulp_docker/plugins/token_util.py
+++ b/plugins/pulp_docker/plugins/token_util.py
@@ -10,20 +10,20 @@ from nectar.request import DownloadRequest
 _logger = logging.getLogger(__name__)
 
 
-def add_auth_header(request, token):
+def update_auth_header(headers, token):
     """
     Adds the token into the request's headers as specified in the Docker v2 API documentation.
 
     https://docs.docker.com/registry/spec/auth/token/#using-the-bearer-token
 
-    :param request: a download request
-    :type  request: nectar.request.DownloadRequest
+    :param headers: headers for a request or session
+    :type  headers: dict or None
     :param token: a Bearer token to be inserted into the Authorization header
     :type  token: basestring
     """
-    if request.headers is None:
-        request.headers = {}
-    request.headers['Authorization'] = 'Bearer %s' % token
+    headers = headers or {}
+    headers['Authorization'] = 'Bearer %s' % token
+    return headers
 
 
 def request_token(downloader, request, response_headers):
@@ -64,6 +64,7 @@ def request_token(downloader, request, response_headers):
     token_data = StringIO()
     token_request = DownloadRequest(token_url, token_data)
     _logger.debug("Requesting token from {url}".format(url=token_url))
+    downloader.session.headers.pop('Authorization', None)
     report = downloader.download_one(token_request)
     if report.state == report.DOWNLOAD_FAILED:
         raise IOError(report.error_msg)

--- a/plugins/test/unit/plugins/test_token_util.py
+++ b/plugins/test/unit/plugins/test_token_util.py
@@ -4,7 +4,7 @@ import mock
 from pulp_docker.plugins import token_util
 
 
-class TestAddAuthHeader(unittest.TestCase):
+class TestUpdateAuthHeader(unittest.TestCase):
     """
     Tests for adding a bearer token to a request header.
     """
@@ -13,22 +13,15 @@ class TestAddAuthHeader(unittest.TestCase):
         """
         Test that when there are no existing headers, it is added.
         """
-        mock_req = mock.MagicMock()
-        mock_req.headers = None
-
-        token_util.add_auth_header(mock_req, "mock token")
-        self.assertDictEqual(mock_req.headers, {"Authorization": "Bearer mock token"})
+        mock_headers = token_util.update_auth_header(None, "mock token")
+        self.assertDictEqual(mock_headers, {"Authorization": "Bearer mock token"})
 
     def test_with_headers(self):
         """
         Test that when the headers exists, the auth token is added to it.
         """
-        mock_req = mock.MagicMock()
-        mock_req.headers = {"mock": "header"}
-
-        token_util.add_auth_header(mock_req, "mock token")
-        self.assertDictEqual(mock_req.headers, {"Authorization": "Bearer mock token",
-                                                "mock": "header"})
+        updated = token_util.update_auth_header({"mock": "header"}, "mock token")
+        self.assertDictEqual(updated, {"Authorization": "Bearer mock token", "mock": "header"})
 
 
 class TestRequestToken(unittest.TestCase):


### PR DESCRIPTION
closes #1644 https://pulp.plan.io/issues/1644
closes #1646 https://pulp.plan.io/issues/1646

Allow Nectar to download with multiple threads at the same time, and
allow each thread to have and reuse its own bearer token. Also
addresses the possibility of infinite recursion if a download remains
unauthorized after retrieving a new token.