### PR TITLE
When a sync cannot get tags from a v2 API, it will fail with a reasonable message.

### DIFF
--- a/common/pulp_docker/common/error_codes.py
+++ b/common/pulp_docker/common/error_codes.py
@@ -19,6 +19,7 @@ DKR1006 = Error("DKR1006", _(
     "a single slash. When %(field)s is not specified, the repo-id value is used. In that case the "
     "repo-id needs to adhere to the same requirements as %(field)s."),
     ['field', 'value'])
-DKR1007 = Error("DKR1007", _("Could not fetch repository %(repo)s from registry %(registry)s"),
-                ['repo', 'registry'])
+DKR1007 = Error("DKR1007", _("Could not fetch repository %(repo)s from registry %(registry)s - "
+                             "%(reason)s"),
+                ['repo', 'registry', 'reason'])
 DKR1008 = Error("DKR1008", _("Could not find registry API at %(registry)s"), ['registry'])

--- a/docs/user-guide/release-notes/2.0.x.rst
+++ b/docs/user-guide/release-notes/2.0.x.rst
@@ -1,8 +1,23 @@
 2.0 Release Notes
 =================
 
+2.0.2
+-----
+
+See the :fixedbugs:`2.0.2`.
+
+The fix for #1831 required that during sync, if the remote registry has a v2 API, but getting tags
+fails, the sync will stop and report an error that the requested repository was not found.
+With 2.0.0, the sync would not report an error. This would allow a graceful fall-back to the v1 API.
+But, the "enable_v1" setting defaults to False, so that resulted in a default behavior to report
+success in the case of failure. Since use of v1 content is now an edge case, and requires manually
+enabling v1 sync, we recommend disabling v2 sync if you do not expect a repository to be available
+via a v2 API.
+
 2.0.1
 -----
+
+See the :fixedbugs:`2.0.1`.
 
 pulp_docker 2.0.1 includes a migration to bring pulp_docker's file storage scheme in-line
 with the scheme used in the Pulp platform.
@@ -10,7 +25,6 @@ with the scheme used in the Pulp platform.
 To apply this migration, follow the Upgrade steps seen below, in the 2.0.0 release notes.
 
 See https://pulp.plan.io/issues/1818 for more details.
-
 
 2.0.0
 -----

--- a/plugins/pulp_docker/plugins/importers/sync.py
+++ b/plugins/pulp_docker/plugins/importers/sync.py
@@ -219,11 +219,8 @@ class DownloadManifestsStep(publish_step.PluginStep):
         super(DownloadManifestsStep, self).process_main()
         _logger.debug(self.description)
 
-        try:
-            available_tags = self.parent.index_repository.get_tags()
-        except IOError:
-            _logger.info(_('Could not get tags through v2 API'))
-            return
+        available_tags = self.parent.index_repository.get_tags()
+
         # This will be a set of Blob digests. The set is used because they can be repeated and we
         # only want to download each layer once.
         available_blobs = set()

--- a/plugins/test/unit/plugins/importers/test_sync.py
+++ b/plugins/test/unit/plugins/importers/test_sync.py
@@ -49,22 +49,6 @@ class TestDownloadManifestsStep(unittest.TestCase):
             step, step_type=constants.SYNC_STEP_METADATA, repo=repo, conduit=conduit, config=config,
             plugin_type=constants.IMPORTER_TYPE_ID)
 
-    def test_cannot_get_tags(self):
-        """
-        Make sure the failure is graceful when v2 tags cannot be retrieved.
-        """
-        repo = mock.MagicMock()
-        conduit = mock.MagicMock()
-        config = mock.MagicMock()
-
-        step = sync.DownloadManifestsStep(repo, conduit, config)
-        step.parent = mock.MagicMock()
-        step.parent.index_repository.get_tags.side_effect = IOError
-
-        step.process_main()
-
-        self.assertEqual(step.parent.available_blobs.extend.call_count, 0)
-
     @mock.patch('pulp_docker.plugins.importers.sync.models.Manifest.from_json',
                 side_effect=models.Manifest.from_json)
     @mock.patch('pulp_docker.plugins.importers.sync.publish_step.PluginStep.process_main')


### PR DESCRIPTION
https://pulp.plan.io/issues/1831

fixes #1831