### PR TITLE
Migrate docker v1 image published links.

### DIFF
--- a/plugins/pulp_docker/plugins/migrations/0002_standard_storage_path.py
+++ b/plugins/pulp_docker/plugins/migrations/0002_standard_storage_path.py
@@ -1,6 +1,6 @@
 from pulp.server.db import connection
 
-from pulp.plugins.migration.standard_storage_path import Migration, Plan
+from pulp.plugins.migration.standard_storage_path import Migration, Plan, Unit
 
 
 def migrate(*args, **kwargs):
@@ -9,7 +9,7 @@ def migrate(*args, **kwargs):
     """
     migration = Migration()
     migration.add(blob_plan())
-    migration.add(image_plan())
+    migration.add(ImagePlan())
     migration.add(manifest_plan())
     migration()
 
@@ -26,18 +26,6 @@ def blob_plan():
     return Plan(collection, key_fields)
 
 
-def image_plan():
-    """
-    Factory to create an image migration plan.
-
-    :return: A configured plan.
-    :rtype: Plan
-    """
-    key_fields = ('image_id',)
-    collection = connection.get_collection('units_docker_image')
-    return Plan(collection, key_fields, join_leaf=False)
-
-
 def manifest_plan():
     """
     Factory to create a manifest migration plan.
@@ -48,3 +36,40 @@ def manifest_plan():
     key_fields = ('digest',)
     collection = connection.get_collection('units_docker_manifest')
     return Plan(collection, key_fields)
+
+
+class ImagePlan(Plan):
+    """
+    Migration plan for Image units.
+    """
+
+    def __init__(self):
+        key_fields = ('image_id',)
+        collection = connection.get_collection('units_docker_image')
+        super(ImagePlan, self).__init__(collection, key_fields, join_leaf=False)
+
+    def _new_unit(self, document):
+        """
+        Create a new unit for the specified document.
+        Provides derived plan classes the opportunity to create specialized
+        unit classes.
+
+        :param document: A content unit document fetched from the DB.
+        :type document: dict
+        :return: A new unit.
+        :rtype: ImageUnit
+        """
+        return ImageUnit(self, document)
+
+
+class ImageUnit(Unit):
+    """
+    Docker image unit.
+    """
+
+    @property
+    def files(self):
+        """
+        List of files (relative paths) associated with the unit.
+        """
+        return ['ancestry', 'json', 'layer']


### PR DESCRIPTION
https://pulp.plan.io/issues/1647

See publisher here: https://github.com/pulp/pulp_docker/blob/2.0-dev/plugins/pulp_docker/plugins/distributors/v1_publish_steps.py#L107