### PR TITLE
Remove intersphinx and enable Strict mode

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W -n
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.intersphinx', 'sphinx.ext.extlinks']
+extensions = ['sphinx.ext.extlinks']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -240,13 +240,6 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
-
-# the "platform" URL needs to point to the correct version of platform docs for
-# this branch of the plugin. It is currently set to "latest" but may change as
-# code is branched and new RTD builders are created for platform.
-
-intersphinx_mapping = {'pylang': ('http://docs.python.org/2.7/', None),
-                       'platform': ("http://pulp.readthedocs.org/en/latest/", None)}
 
 extlinks = {'redmine': ('https://pulp.plan.io/issues/%s', '#'),
             'fixedbugs': ('https://pulp.plan.io/projects/pulp_docker/issues?utf8=%%E2%%9C%%93&'

--- a/docs/user-guide/configuration.rst
+++ b/docs/user-guide/configuration.rst
@@ -11,7 +11,7 @@ The Docker importer is configured by editing
 
 The importer supports the settings documented in Pulp's `importer config docs`_.
 
-.. _importer config docs: https://pulp.readthedocs.org/en/latest/user-guide/server.html#importers
+.. _importer config docs: https://docs.pulpproject.org/en/latest/user-guide/server.html#importers
 
 The following docker specific properties are supported:
 

--- a/docs/user-guide/installation.rst
+++ b/docs/user-guide/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-.. _Pulp User Guide: http://pulp.readthedocs.org
+.. _Pulp User Guide: https://docs.pulpproject.org
 
 Prerequisites
 -------------


### PR DESCRIPTION
Intersphinx was preventing the strict mode from being enabled
due to docs being built in a network isolated mock environment.

Intersphinx was also going to break because it is tied
to URLs from ReadTheDocs. Now intersphinx is removed.
Strict Sphinx mode is now enabled.

Links are also updated to point to docs.pulpproject.org

https://pulp.plan.io/issues/2034
re #2034