### PR TITLE
Adds rsync distributor

### DIFF
--- a/common/pulp_docker/common/error_codes.py
+++ b/common/pulp_docker/common/error_codes.py
@@ -23,3 +23,5 @@ DKR1007 = Error("DKR1007", _("Could not fetch repository %(repo)s from registry 
                              "%(reason)s"),
                 ['repo', 'registry', 'reason'])
 DKR1008 = Error("DKR1008", _("Could not find registry API at %(registry)s"), ['registry'])
+DKR1009 = Error("DKR1009", _("Docker rsync distributor configuration requires a "
+                             "postdistributor_id."), [])

--- a/docs/tech-reference/distributor.rst
+++ b/docs/tech-reference/distributor.rst
@@ -160,3 +160,83 @@ Example Redirect File Contents::
     ],
   "tags": {"latest": "769b9341d937a3dba9e460f664b4f183a6cecdd62b337220a28b3deb50ee0a02"}
  }
+
+Docker rsync Distributor
+------------------------
+
+Purpose:
+--------
+The Docker rsync distributor publishes docker content to a remote server. The distributor uses
+rsync over ssh to perform the file transfer. Docker images (v1) are published into the root of
+the remote repository. Manifests (v2) are published into ``manifests`` directory and Blobs (v2) are
+published into ``blobs`` directory.
+
+The docker rsync distributor makes it easier to serve docker content on one server and run Crane on
+another server. It is recommended that the rsync distributor is used required to publish prior to
+publishing with the docker web distributor.
+
+Configuration
+=============
+Here is an example docker_rsync_distributor configuration:
+
+.. code-block:: json
+
+    {
+     "distributor_id": "my_docker_rsync_distributor",
+     "distributor_type_id": "docker_rsync_distributor",
+     "distributor_config": {
+        "remote": {
+            "auth_type": "publickey",
+            "ssh_user": "foo",
+            "ssh_identity_file": "/home/user/.ssh/id_rsa",
+            "host": "192.168.121.1",
+            "root": "/home/foo/pulp_root_dir"
+        },
+        "postdistributor_id": "docker_web_distributor_name_cli"
+     }
+    }
+
+
+``postdistributor_id``
+  The id of the docker_distributor_web associated with the same repository. The
+  ``repo-registry-id`` configured in the postdistributor will be used when generating tags list.
+   The docker web distributor associated with the same repository is required to have the
+   ``predistributor_id`` configured. ``postdistributor_id`` is a required config.
+
+The ``distributor_config`` contains a ``remote`` section with the following settings:
+
+``auth_type``
+  Two authentication methods are supported: ``publickey`` and ``password``.
+
+``ssh_user``
+  The ssh user for remote server.
+
+``ssh_identity_file``
+  The path to the private key to be used as the ssh identity file. When ``auth_type`` is
+  ``publickey`` this is a required config. The key has to be readable by user ``apache``.
+
+``ssh_password``
+  The password to be used for ``ssh_user`` on the remote server. ``ssh_password`` is required when
+  ``auth_type`` is 'password'.
+
+``host``
+  The hostname of the remote server.
+
+``root``
+  The absolute path to the remote root directory where all the data (content and published content)
+  lives. This is the remote equivalent to ``/var/lib/pulp``. The repo id is appended to the
+  ``root`` path to determine the location of published repository.
+
+Optional Configuration
+----------------------
+
+``content_units_only``
+  If true, the distributor will publish content units only (e.g. ``/var/lib/pulp/content``). The
+  symlinks of a published repository will not be rsynced.
+
+``delete``
+  If true, ``--delete`` is appended to the rsync command for symlinks and repodata so that any old
+  files no longer present in the local published directory are removed from the remote server.
+
+``remote_units_path``
+  The relative path from the ``root`` where unit files will live. Defaults to ``content/units``.

--- a/plugins/pulp_docker/plugins/distributors/rsync_distributor.py
+++ b/plugins/pulp_docker/plugins/distributors/rsync_distributor.py
@@ -1,0 +1,100 @@
+from gettext import gettext as _
+import logging
+
+from pulp.common.config import read_json_config
+from pulp.plugins.distributor import Distributor
+
+from pulp_docker.common.constants import BLOB_TYPE_ID, IMAGE_TYPE_ID, MANIFEST_TYPE_ID, TAG_TYPE_ID
+from pulp_docker.plugins.distributors import configuration
+from pulp_docker.plugins.distributors.publish_steps import DockerRsyncPublisher
+
+TYPES = (IMAGE_TYPE_ID, BLOB_TYPE_ID, MANIFEST_TYPE_ID, TAG_TYPE_ID)
+
+TYPE_ID_DISTRIBUTOR_DOCKER_RSYNC = 'docker_rsync_distributor'
+CONF_FILE_PATH = 'server/plugins.conf.d/%s.json' % TYPE_ID_DISTRIBUTOR_DOCKER_RSYNC
+
+DISTRIBUTOR_DISPLAY_NAME = 'Docker Rsync Distributor'
+
+
+_LOG = logging.getLogger(__name__)
+
+
+# -- entry point ---------------------------------------------------------------
+
+def entry_point():
+    config = read_json_config(CONF_FILE_PATH)
+    return DockerRsyncDistributor, config
+
+
+class DockerRsyncDistributor(Distributor):
+    """
+    Distributor class for publishing repo directory to RH CDN
+    """
+
+    def __init__(self):
+        super(DockerRsyncDistributor, self).__init__()
+
+        self.canceled = False
+        self._publisher = None
+
+    @classmethod
+    def metadata(cls):
+        """
+        Used by Pulp to classify the capabilities of this distributor.
+
+        :return: description of the distributor's capabilities
+        :rtype:  dict
+        """
+        return {'id': TYPE_ID_DISTRIBUTOR_DOCKER_RSYNC,
+                'display_name': DISTRIBUTOR_DISPLAY_NAME,
+                'types': TYPES}
+
+    # -- repo lifecycle methods ------------------------------------------------
+
+    def validate_config(self, repo, config, config_conduit):
+        """
+        Allows the distributor to check the contents of a potential configuration
+        for the given repository. This call is made both for the addition of
+        this distributor to a new repository as well as updating the configuration
+        for this distributor on a previously configured repository.
+
+        :param repo: metadata describing the repository to which the
+                     configuration applies
+        :type  repo: pulp.plugins.model.Repository
+
+        :param config: plugin configuration instance; the proposed repo
+                       configuration is found within
+        :type  config: pulp.plugins.config.PluginCallConfiguration
+
+        :param config_conduit: Configuration Conduit;
+        :type  config_conduit: pulp.plugins.conduits.repo_config.RepoConfigConduit
+
+        :return: tuple of (bool, str) to describe the result
+        :rtype:  tuple
+        """
+        _LOG.debug(_('Validating docker repository configuration: %(repoid)s') %
+                   {'repoid': repo.id})
+        return configuration.validate_rsync_distributor_config(repo, config, config_conduit)
+
+    # -- actions ---------------------------------------------------------------
+
+    def publish_repo(self, repo, publish_conduit, config):
+        """
+        Publishes the given repository.
+
+        :param repo: metadata describing the repository
+        :type  repo: pulp.plugins.model.Repository
+
+        :param publish_conduit: provides access to relevant Pulp functionality
+        :type  publish_conduit: pulp.plugins.conduits.repo_publish.RepoPublishConduit
+
+        :param config: plugin configuration
+        :type  config: pulp.plugins.config.PluginConfiguration
+
+        :return: report describing the publish run
+        :rtype:  pulp.plugins.model.PublishReport
+        """
+        _LOG.debug(_('Publishing Docker repository: %(repoid)s') % {'repoid': repo.id})
+        self._publisher = DockerRsyncPublisher(repo, publish_conduit, config,
+                                               TYPE_ID_DISTRIBUTOR_DOCKER_RSYNC)
+        return self._publisher.publish()

--- a/plugins/pulp_docker/plugins/models.py
+++ b/plugins/pulp_docker/plugins/models.py
@@ -30,6 +30,14 @@ class Blob(pulp_models.FileContentUnit):
             'indexes': [],
             'allow_inheritance': False}
 
+    def get_symlink_name(self):
+        """
+        Provides the name that should be used when creating a symlink.
+        :return: file name as it appears in a published repository
+        :rtype: str
+        """
+        return self.digest
+
 
 class Image(pulp_models.FileContentUnit):
     """
@@ -58,6 +66,14 @@ class Image(pulp_models.FileContentUnit):
         """
         names = ('ancestry', 'json', 'layer')
         return [os.path.join(self.storage_path, n) for n in names]
+
+    def get_symlink_name(self):
+        """
+        Provides the name that should be used when creating a symlink.
+        :return: file name as it appears in a published repository
+        :rtype: str
+        """
+        return self.image_id
 
 
 class FSLayer(mongoengine.EmbeddedDocument):
@@ -191,6 +207,14 @@ class Manifest(pulp_models.FileContentUnit):
         fs_layers = [FSLayer(blob_sum=layer['blobSum']) for layer in manifest['fsLayers']]
         return cls(digest=digest, name=manifest['name'], tag=manifest['tag'],
                    schema_version=manifest['schemaVersion'], fs_layers=fs_layers)
+
+    def get_symlink_name(self):
+        """
+        Provides the name that should be used when creating a symlink.
+        :return: file name as it appears in a published repository
+        :rtype: str
+        """
+        return self.digest
 
 
 class TagQuerySet(querysets.QuerySetPreventCache):

--- a/plugins/setup.py
+++ b/plugins/setup.py
@@ -19,6 +19,7 @@ setup(
         'pulp.distributors': [
             'web_distributor = pulp_docker.plugins.distributors.distributor_web:entry_point',
             'export_distributor = pulp_docker.plugins.distributors.distributor_export:entry_point',
+            'rsync_distributor = pulp_docker.plugins.distributors.rsync_distributor:entry_point'
         ],
         'pulp.server.db.migrations': [
             'pulp_docker = pulp_docker.plugins.migrations'

--- a/pulp-docker.spec
+++ b/pulp-docker.spec
@@ -96,6 +96,7 @@ Requires: python-pulp-docker-common = %{version}
 Requires: pulp-server >= 2.8.0
 Requires: python-setuptools
 Requires: python-nectar >= 1.3.0
+Requires: rsync
 
 %description plugins
 Provides a collection of platform plugins that extend the Pulp platform


### PR DESCRIPTION
This commit adds the docker rsync distributor. However, publishing with the docker rsync distributor does not affect the publish with the web distributor. Separate commit will bring in that functionality.

re #1887
https://pulp.plan.io/issues/1887