### PR TITLE
Adds support for relative_repo_path for the docker rsync distributor

### DIFF
--- a/docs/tech-reference/distributor.rst
+++ b/docs/tech-reference/distributor.rst
@@ -240,3 +240,6 @@ Optional Configuration
 
 ``remote_units_path``
   The relative path from the ``root`` where unit files will live. Defaults to ``content/units``.
+
+``relative_repo_path``
+  The relative path from the ``root`` where the repository will be published. Defaults to the repository id.

--- a/plugins/pulp_docker/plugins/distributors/configuration.py
+++ b/plugins/pulp_docker/plugins/distributors/configuration.py
@@ -232,6 +232,22 @@ def get_repo_relative_path(repo, config):
     return repo.id
 
 
+def get_remote_repo_relative_path(repo, config):
+    """
+    Get the configured relative path for the given repository. This method is used by rsync
+    distributor. When repo_relative_path is not set, repository id is returned.
+
+    :param repo: repository to get relative path for
+    :type  repo: pulp.plugins.model.Repository
+    :param config: configuration instance for the repository
+    :type  config: pulp.plugins.config.PluginCallConfiguration or dict
+
+    :return: relative path for the repository
+    :rtype:  str
+    """
+    return config.get('repo_relative_path', repo.id)
+
+
 def get_export_repo_directory(config, docker_api_version):
     """
     Get the directory where the export publisher will publish repositories.

--- a/plugins/pulp_docker/plugins/distributors/publish_steps.py
+++ b/plugins/pulp_docker/plugins/distributors/publish_steps.py
@@ -381,7 +381,7 @@ class DockerRsyncPublisher(Publisher):
         """
         postdistributor = self._get_postdistributor()
         repo_registry_id = configuration.get_repo_registry_id(self.repo, postdistributor.config)
-        remote_repo_path = configuration.get_repo_relative_path(self.repo, self.config)
+        remote_repo_path = configuration.get_remote_repo_relative_path(self.repo, self.config)
 
         unit_info = {constants.IMAGE_TYPE_ID: {'extra_path': [''], 'model': models.Image},
                      constants.MANIFEST_TYPE_ID: {'extra_path': ['manifests'],


### PR DESCRIPTION
re #1887
https://pulp.plan.io/issues/1887