### PR TITLE
As a user, I can sync manifests schema version 2. 

### DIFF
--- a/docs/tech-reference/distributor.rst
+++ b/docs/tech-reference/distributor.rst
@@ -32,7 +32,7 @@ Supported keys
 ``protected``
  if "true" requests for this repo will be checked for an entitlement certificate authorizing
  the server url for this repository; if "false" no authorization checking will be done.
- This defaults to true.
+ This defaults to false.
 
 ``redirect-url``
  The server URL that will be used when generating the redirect map for connecting the Docker
@@ -92,6 +92,38 @@ Supported keys
 
 .. _redirect_file:
 
+V3 Redirect File
+----------------
+
+For Docker v2 content, the distributors generate a json file with the details of the repository
+contents.
+
+The file is JSON formatted with the following keys
+
+* **type** *(string)* - the type of file. This will always be "pulp-docker-redirect".
+* **version** *(int)* - version of the format for the file. For Docker v2, that supports manifest schema,
+                        this will be 3.
+* **repository** *(string)* - the name of the repository this file is describing.
+* **repo-registry-id** *(string)* - the name that will be used for this repository in the Docker
+  registry.
+* **url** *(string)* - the URL for accessing the repository content.
+* **schema2_data** *(array)* - an array of tags and digests that schema version 2 manifests reference.
+* **protected** *(bool)* - whether or not the repository should be protected by an entitlement
+  certificate.
+
+Example Redirect File Contents::
+
+ {
+  "type":"pulp-docker-redirect",
+  "version":3,
+  "repository":"docker",
+  "repo-registry-id":"redhat/docker",
+  "url":"http://www.foo.com/docker",
+  "schema2_data":[]}
+  "protected": false
+ }
+
+
 V2 Redirect File
 ----------------
 
@@ -100,12 +132,12 @@ contents.
 
 The file is JSON formatted with the following keys
 
-* **type** *(string)* - the type of the file. This will always be "pulp-docker-redirect".
+* **type** *(string)* - the type of file. This will always be "pulp-docker-redirect".
 * **version** *(int)* - version of the format for the file. For Docker v2, this will be 2.
 * **repository** *(string)* - the name of the repository this file is describing.
 * **repo-registry-id** *(string)* - the name that will be used for this repository in the Docker
   registry.
-* **url** *(string)* - the url for access to the repository's content.
+* **url** *(string)* - the URL for accessing the repository content.
 * **protected** *(bool)* - whether or not the repository should be protected by an entitlement
   certificate.
 
@@ -117,7 +149,7 @@ Example Redirect File Contents::
   "repository":"docker",
   "repo-registry-id":"redhat/docker",
   "url":"http://www.foo.com/docker",
-  "protected": true
+  "protected": false
  }
 
 
@@ -129,19 +161,19 @@ repository contents.
 
 The file is JSON formatted with the following keys
 
-* **type** *(string)* - the type of the file. This will always be "pulp-docker-redirect".
+* **type** *(string)* - the type of file. This will always be "pulp-docker-redirect".
 * **version** *(int)* - version of the format for the file. For Docker v1, this will be 1.
 * **repository** *(string)* - the name of the repository this file is describing.
 * **repo-registry-id** *(string)* - the name that will be used for this repository in the Docker
   registry.
-* **url** *(string)* - the url for access to the repository's content.
+* **url** *(string)* - the URL for accessing the repository content.
 * **protected** *(bool)* - whether or not the repository should be protected by an entitlement
   certificate.
 * **images** *(array)* - an array of objects describing each image/layer in the repository.
 
   * **id** *(str)* - the image id for the image.
 
-* **tags** *(obj)* - an object containing key, value paris of "tag-name":"image-id".
+* **tags** *(obj)* - an object containing key, value pairs of "tag-name":"image-id".
 
 Example Redirect File Contents::
 
@@ -151,7 +183,7 @@ Example Redirect File Contents::
   "repository":"docker",
   "repo-registry-id":"redhat/docker",
   "url":"http://www.foo.com/docker",
-  "protected": true,
+  "protected": false,
   "images":[
     {"id":"48e5f45168b97799ad0aafb7e2fef9fac57b5f16f6db7f67ba2000eb947637eb"},
     {"id":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158"},

--- a/docs/tech-reference/tags.rst
+++ b/docs/tech-reference/tags.rst
@@ -5,22 +5,60 @@ v2
 --
 
 Manifest Tags are stored as Pulp Units. Each Tag has a name, a manifest_digest
-(the digest of the Manifest that the Tag references), and a repo_id. A Tag's
-name and repo_id must be unique together so that in any given repository a Tag
-name only references a single Manifest. Here is an example tag from MongoDB::
+(the digest of the Manifest that the Tag references), schema_version (the schema version
+for the manifest the Tag references) and a repo_id. A Tag's name, schema_version and repo_id
+must be unique together so that in any given repository a Tag only references
+a single Manifest that uses either schema version 1 or schema version 2.
+Here is an example of tag with name 'latest' within a repository::
 
-    {
-        "_id" : "4e50e89a-fbd9-454e-8f05-22a439698264",
-        "pulp_user_metadata" : {
-
+    [
+      {
+        "updated": "2017-02-09T15:52:46Z",
+        "repo_id": "synctest",
+        "created": "2017-02-09T15:52:46Z",
+        "_ns": "repo_content_units",
+        "unit_id": "19986269-4666-4dad-acbe-b0cce808bb21",
+        "unit_type_id": "docker_tag",
+        "_id": {
+          "$oid": "589c904e45ef487707c641fa"
         },
-        "_last_updated" : 1455043172,
-        "name" : "1-glibc",
-        "manifest_digest" : "sha256:d5ad6f092d781a71630261dc7ee6503bafb8c39e2c918e13c9e0765e10758a9b",
-        "repo_id" : "synctest",
-        "_ns" : "units_docker_tag",
-        "_content_type_id" : "docker_tag"
-    }
+        "id": "589c904e45ef487707c641fa",
+        "metadata": {
+          "repo_id": "synctest",
+          "manifest_digest": "sha256:817a12c32a39bbe394944ba49de563e085f1d3c5266eb8e9723256bc4448680e",
+          "_ns": "units_docker_tag",
+          "_last_updated": 1486655449,
+          "schema_version": 2,
+          "pulp_user_metadata": {},
+          "_content_type_id": "docker_tag",
+          "_id": "19986269-4666-4dad-acbe-b0cce808bb21",
+          "name": "latest"
+        }
+      },
+      {
+        "updated": "2017-02-09T16:02:54Z",
+        "repo_id": "synctest",
+        "created": "2017-02-09T16:02:54Z",
+        "_ns": "repo_content_units",
+        "unit_id": "7f92741b-5379-4f13-8b43-0d3ebd9c5c25",
+        "unit_type_id": "docker_tag",
+        "_id": {
+          "$oid": "589c92ae45ef487707c641fd"
+        },
+        "id": "589c92ae45ef487707c641fd",
+        "metadata": {
+          "repo_id": "synctest",
+          "manifest_digest": "sha256:c152ddeda2b828fbb610cb9e4cb121e1879dd5301d336f0a6c070b2844a0f56d",
+          "_ns": "units_docker_tag",
+          "_last_updated": 1486653137,
+          "schema_version": 1,
+          "pulp_user_metadata": {},
+          "_content_type_id": "docker_tag",
+          "_id": "7f92741b-5379-4f13-8b43-0d3ebd9c5c25",
+          "name": "latest"
+        }
+      }
+    ]
 
 
 v1

--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -363,6 +363,13 @@ the tag we specify does not exist, it will be created. If the tag exists
 however, it will be updated as tag name is unique per repository and can point
 to only one manifest.
 
+.. note::
+
+    Pulp now supports manifest schema 1 and schema 2 versions. So when tagging a manifest,
+    bear in mind that within a repo there could be two tags with the same name but pointing
+    to manifests with different schema versions.
+
+
 For instance, suppose we have the following manifests::
 
     $ pulp-admin docker repo search manifest --repo-id busybox

--- a/docs/user-guide/release-notes/2.4.x.rst
+++ b/docs/user-guide/release-notes/2.4.x.rst
@@ -1,0 +1,16 @@
+2.4 Release Notes
+=================
+
+2.4.0
+-----
+
+Manifest V2 schema version 2 is now supported. It can be normally synced into Pulp from
+docker registry, published and served by Crane.
+Support for manifest V2 schema version 1 did not change.
+
+Publish directory structure for manifests has been changed to manage more effectively manifest
+schema versions. Now each manifest schema version has its own directory `manifests/1` and
+`manifests/2`. This change will not affect already published content, it will take place with
+the new publish action.
+
+A new `redirect file` format has been introduced to enable Crane to serve both schema versions.

--- a/docs/user-guide/release-notes/index.rst
+++ b/docs/user-guide/release-notes/index.rst
@@ -6,6 +6,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   2.4.x
    2.3.x
    2.2.x
    2.1.x

--- a/extensions_admin/pulp_docker/extensions/admin/upload.py
+++ b/extensions_admin/pulp_docker/extensions/admin/upload.py
@@ -118,6 +118,7 @@ class TagUpdateCommand(UploadCommand):
 
         tag_name = kwargs[TAG_NAME_OPTION.keyword]
         repo_id = kwargs[std_options.OPTION_REPO_ID.keyword]
+
         return {'name': tag_name, 'repo_id': repo_id}
 
     def generate_metadata(self, filename, **kwargs):

--- a/plugins/etc/httpd/conf.d/pulp_docker.conf
+++ b/plugins/etc/httpd/conf.d/pulp_docker.conf
@@ -15,6 +15,12 @@ Alias /pulp/docker/v2 /var/www/pub/docker/v2/web
     SSLRequireSSL
     Options FollowSymlinks Indexes
 </Directory>
+<Directory /var/www/pub/docker/v2/web/*/manifests/2>
+    Header set Docker-Distribution-API-Version "registry/2.0"
+    Header set Content-Type "application/vnd.docker.distribution.manifest.v2+json"
+    SSLRequireSSL
+    Options FollowSymlinks Indexes
+</Directory>
 
 # Docker v1
 Alias /pulp/docker/v1 /var/www/pub/docker/v1/web

--- a/plugins/pulp_docker/plugins/migrations/0003_tag_schema_change.py
+++ b/plugins/pulp_docker/plugins/migrations/0003_tag_schema_change.py
@@ -1,0 +1,20 @@
+from pulp.server.db.connection import get_collection
+
+
+def migrate(*args, **kwargs):
+    """
+    Add schema_version to the tag collection.
+    """
+
+    schema_version_key = 'schema_version'
+    collection = get_collection('units_docker_tag')
+    # drop old index due to unit_keys fields change
+    index_info = collection.index_information()
+    old_index = 'name_1_repo_id_1'
+    if old_index in index_info:
+        collection.drop_index(old_index)
+    # update collection with new field
+    for tag in collection.find():
+        if schema_version_key not in tag.keys():
+            tag[schema_version_key] = 1
+            collection.save(tag)

--- a/plugins/test/data/manifest_schema2_one_layer.json
+++ b/plugins/test/data/manifest_schema2_one_layer.json
@@ -1,0 +1,16 @@
+{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+   "config": {
+      "mediaType": "application/vnd.docker.container.image.v1+json",
+      "size": 1465,
+      "digest": "sha256:7968321274dc6b6171697c33df7815310468e694ac5be0ec03ff053bb135e768"
+   },
+   "layers": [
+      {
+         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+         "size": 677628,
+         "digest": "sha256:4b0bc1c4050b03c95ef2a8e36e25feac42fd31283e8c30b3ee5df6b043155d3c"
+      }
+   ]
+}

--- a/plugins/test/unit/plugins/distributors/test_distributor_export.py
+++ b/plugins/test/unit/plugins/distributors/test_distributor_export.py
@@ -98,7 +98,7 @@ class TestBasics(unittest.TestCase):
         conduit = RepoPublishConduit(repo.id, 'foo_repo')
         self.distributor.publish_repo(repo, conduit, config)
 
-        mock_publisher.return_value.assert_called_once()
+        mock_publisher.assert_called_once()
 
     def test_cancel_publish_repo(self):
         self.distributor._publisher = MagicMock()

--- a/plugins/test/unit/plugins/distributors/test_distributor_web.py
+++ b/plugins/test/unit/plugins/distributors/test_distributor_web.py
@@ -105,7 +105,7 @@ class TestBasics(unittest.TestCase):
         conduit = RepoPublishConduit(repo.id, 'foo_repo')
         self.distributor.publish_repo(repo, conduit, config)
 
-        mock_publisher.return_value.assert_called_once()
+        mock_publisher.assert_called_once()
 
     def test_cancel_publish_repo(self):
         self.distributor._publisher = MagicMock()

--- a/plugins/test/unit/plugins/migrations/test_0003_tag_schema_change.py
+++ b/plugins/test/unit/plugins/migrations/test_0003_tag_schema_change.py
@@ -1,0 +1,45 @@
+"""
+This module contains tests for pulp_docker.plugins.migrations.0003_tag_schema_change.py
+"""
+from copy import deepcopy
+from unittest import TestCase
+
+from mock import Mock, patch
+
+from pulp.server.db.migrate.models import _import_all_the_way
+
+
+PATH_TO_MODULE = 'pulp_docker.plugins.migrations.0003_tag_schema_change'
+
+migration = _import_all_the_way(PATH_TO_MODULE)
+
+SCHEMA_VERSION = 'schema_version'
+
+
+class TestMigration(TestCase):
+    """
+    Test the migration.
+    """
+
+    @patch('.'.join((PATH_TO_MODULE, 'get_collection')))
+    def test_migrate(self, m_get_collection):
+        """
+        Test schema_version field added and collection index dropped.
+        """
+        collection = Mock()
+        found = [
+            {SCHEMA_VERSION: 1}, {}, {SCHEMA_VERSION: 2}
+        ]
+        collection.find.return_value = deepcopy(found)
+        collection.index_information.return_value = ['name_1_repo_id_1']
+        m_get_collection.return_value = collection
+
+        # test
+        migration.migrate()
+
+        # validation
+        collection.drop_index.assert_called_once_with('name_1_repo_id_1')
+        collection.find.assert_called_once_with()
+        m_get_collection.assert_called_once_with('units_docker_tag')
+        self.assertTrue(SCHEMA_VERSION in tags for tags in collection.save.call_args_list)
+        self.assertEqual(len(collection.save.call_args_list), 1)

--- a/plugins/test/unit/plugins/test_registry.py
+++ b/plugins/test/unit/plugins/test_registry.py
@@ -150,7 +150,7 @@ class TestAPIVersionCheck(unittest.TestCase):
         self.repo = registry.V1Repository('pulp/crane', self.config,
                                           'http://pulpproject.org/', '/a/b/c')
 
-    @mock.patch.object(registry.V1Repository, '_get_single_path', spec_set=True)
+    @mock.patch.object(registry.V1Repository, '_get_single_path')
     def test_success(self, mock_get_path):
         ret = self.repo.api_version_check()
 
@@ -516,7 +516,8 @@ class TestV2Repository(unittest.TestCase):
             report = DownloadReport(request.url, request.destination)
             report.download_succeeded()
             report.headers = {'Docker-Distribution-API-Version': 'registry/2.0',
-                              'docker-content-digest': digest}
+                              'docker-content-digest': digest,
+                              'Content-Type': 'not schema2 type'}
             report.destination.write(manifest)
             return report
 
@@ -530,10 +531,9 @@ class TestV2Repository(unittest.TestCase):
         with open(os.path.join(TEST_DATA_PATH, 'manifest_repeated_layers.json')) as manifest_file:
             manifest = manifest_file.read()
 
-        d, m = r.get_manifest('best_version_ever')
+        m = r.get_manifest('best_version_ever')
 
-        self.assertEqual(d, digest)
-        self.assertEqual(m, manifest)
+        self.assertEqual([(manifest, digest)], m)
 
     def test_get_tags(self):
         """


### PR DESCRIPTION
- [x] add documentation 
- [x] add release notes
- [x] test copy operation works with tags, manifestsm blobs
- [x] test remove operation works with tags, manifests, blobs
- [x] test `docker repo tag` works
- [x] test docker rsync distributor works 
- [x] test docker export distributor did not break because of new changes
- [x] update broken tests
- [x] create some tests for coverage
- [x] add smash issue with different scenarios
- [x] test schema2 workflow on upgraded env and fresh install --> sync-publish-crane-docker pull 
