### PR TITLE
Add provides for python2-* packages

### DIFF
--- a/pulp-docker.spec
+++ b/pulp-docker.spec
@@ -70,6 +70,7 @@ rm -rf %{buildroot}
 %package -n python-pulp-docker-common
 Summary: Pulp Docker support common library
 Group: Development/Languages
+Provides: python2-pulp-docker-common
 Requires: python-pulp-common >= 2.8.0
 Requires: python-setuptools
 


### PR DESCRIPTION
Add provides for python2-* packages.  Fedora downstream packages are
named python2-* and provide python-*.  Upstream needs to mirror this for
dependency resolution to work properly

re #2687