### PR TITLE
Rectify repo relative path in docs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
+Muhammad Ammar Ansari <mansari@redhat.com>
 Randy Barlow <rbarlow@redhat.com>
 Barnaby Court <bcourt@redhat.com>
 Patrick Creech <pcreech@redhat.com>

--- a/docs/tech-reference/distributor.rst
+++ b/docs/tech-reference/distributor.rst
@@ -276,5 +276,5 @@ Optional Configuration
 ``remote_units_path``
   The relative path from the ``root`` where unit files will live. Defaults to ``content/units``.
 
-``relative_repo_path``
+``repo_relative_path``
   The relative path from the ``root`` where the repository will be published. Defaults to the repository id.


### PR DESCRIPTION
'relative_repo_path' in docs should be
'repo_relative_path'

fixes #2678