### PR TITLE
docker_distributor_web advertises supporting v2 unit types

### DIFF
--- a/common/pulp_docker/common/constants.py
+++ b/common/pulp_docker/common/constants.py
@@ -73,3 +73,5 @@ MEDIATYPE_MANIFEST_LIST = 'application/vnd.docker.distribution.manifest.list.v2+
 MEDIATYPE_MANIFEST_S1 = 'application/vnd.docker.distribution.manifest.v1+json'
 MEDIATYPE_MANIFEST_S2 = 'application/vnd.docker.distribution.manifest.v2+json'
 MEDIATYPE_SIGNED_MANIFEST_S1 = 'application/vnd.docker.distribution.manifest.v1+prettyjws'
+
+SUPPORTED_TYPES = (IMAGE_TYPE_ID, BLOB_TYPE_ID, MANIFEST_TYPE_ID, TAG_TYPE_ID)

--- a/plugins/pulp_docker/plugins/distributors/distributor_web.py
+++ b/plugins/pulp_docker/plugins/distributors/distributor_web.py
@@ -51,7 +51,7 @@ class DockerWebDistributor(Distributor):
         return {
             'id': constants.DISTRIBUTOR_WEB_TYPE_ID,
             'display_name': _('Docker Web Distributor'),
-            'types': [constants.IMAGE_TYPE_ID]
+            'types': constants.SUPPORTED_TYPES,
         }
 
     def __init__(self):

--- a/plugins/pulp_docker/plugins/distributors/rsync_distributor.py
+++ b/plugins/pulp_docker/plugins/distributors/rsync_distributor.py
@@ -4,11 +4,9 @@ import logging
 from pulp.common.config import read_json_config
 from pulp.plugins.distributor import Distributor
 
-from pulp_docker.common.constants import BLOB_TYPE_ID, IMAGE_TYPE_ID, MANIFEST_TYPE_ID, TAG_TYPE_ID
+from pulp_docker.common import constants
 from pulp_docker.plugins.distributors import configuration
 from pulp_docker.plugins.distributors.publish_steps import DockerRsyncPublisher
-
-TYPES = (IMAGE_TYPE_ID, BLOB_TYPE_ID, MANIFEST_TYPE_ID, TAG_TYPE_ID)
 
 TYPE_ID_DISTRIBUTOR_DOCKER_RSYNC = 'docker_rsync_distributor'
 CONF_FILE_PATH = 'server/plugins.conf.d/%s.json' % TYPE_ID_DISTRIBUTOR_DOCKER_RSYNC
@@ -47,7 +45,7 @@ class DockerRsyncDistributor(Distributor):
         """
         return {'id': TYPE_ID_DISTRIBUTOR_DOCKER_RSYNC,
                 'display_name': DISTRIBUTOR_DISPLAY_NAME,
-                'types': TYPES}
+                'types': constants.SUPPORTED_TYPES}
 
     # -- repo lifecycle methods ------------------------------------------------
 

--- a/plugins/test/unit/plugins/distributors/test_distributor_web.py
+++ b/plugins/test/unit/plugins/distributors/test_distributor_web.py
@@ -40,7 +40,7 @@ class TestBasics(unittest.TestCase):
         metadata = DockerWebDistributor.metadata()
 
         self.assertEqual(metadata['id'], constants.DISTRIBUTOR_WEB_TYPE_ID)
-        self.assertEqual(metadata['types'], [constants.IMAGE_TYPE_ID])
+        self.assertEqual(metadata['types'], constants.SUPPORTED_TYPES)
         self.assertTrue(len(metadata['display_name']) > 0)
 
     @patch('pulp_docker.plugins.distributors.distributor_web.configuration.validate_config')


### PR DESCRIPTION
The types supported by docker_distributor_web include
docker_blob, docker_manifest, docker_tag

closes #3241
https://pulp.plan.io/issues/3241