### PR TITLE
Prefer manifest_digest over digest, the actual field name on the model.

### DIFF
--- a/common/pulp_docker/common/error_codes.py
+++ b/common/pulp_docker/common/error_codes.py
@@ -46,3 +46,5 @@ DKR1017 = Error("DKR1017", _("Checksum %(checksum)s (%(checksum_type)s) does not
                 ['checksum_type', 'checksum'])
 DKR1018 = Error("DKR1018", _("Layer %(layer)s is not present in the image"),
                 ['layer'])
+DKR1019 = Error("DKR1019", _("Tag does not contain required field: %(field)s."),
+                ['field'])

--- a/plugins/pulp_docker/plugins/importers/upload.py
+++ b/plugins/pulp_docker/plugins/importers/upload.py
@@ -328,8 +328,16 @@ class AddTags(PluginStep):
         :type  item: None
         """
 
-        tag = self.parent.metadata['name']
-        digest = self.parent.metadata['digest']
+        md = self.parent.metadata
+        tag = md.get('name')
+        if tag is None:
+            raise PulpCodedValidationException(error_code=error_codes.DKR1019,
+                                               field='name')
+        # https://pulp.plan.io/issues/3250 - use manifest_digest if available
+        digest = md.get('manifest_digest', md.get('digest'))
+        if digest is None:
+            raise PulpCodedValidationException(error_code=error_codes.DKR1019,
+                                               field='manifest_digest')
         repo_id = self.parent.repo.id
         manifest_type_id = models.Manifest._content_type_id.default
         repo_manifest_ids = repository.get_associated_unit_ids(repo_id, manifest_type_id)


### PR DESCRIPTION
Raise a validation exception if name or manifest_digest are missing.
Added tests.

closes #3250
https://pulp.plan.io/issues/3250