### PR TITLE
Advise users on using setsebool to set pulp_manage_rsync selinux boolean

### DIFF
--- a/docs/tech-reference/distributor.rst
+++ b/docs/tech-reference/distributor.rst
@@ -274,10 +274,10 @@ Configuration
 =============
 Pulp's SELinux policy includes a ``pulp_manage_rsync`` boolean. When enabled, the
 ``pulp_manage_rsync`` boolean allows Pulp to use rsync and make ssh connections. The boolean is
-disabled by default. The RPM Rsync distributor will fail to publish with SELinux Enforcing unless
-the boolean is enabled. To enable it, you can do this::
+disabled by default. The Docker Rsync distributor will fail to publish with SELinux Enforcing
+unless the boolean is enabled. To enable it, you can do this::
 
-    $ sudo semanage boolean --modify --on pulp_manage_rsync
+    $ sudo setsebool -P pulp_manage_rsync on
 
 Here is an example docker_rsync_distributor configuration::
 


### PR DESCRIPTION
F27+ changed the behavior of semanage to set a selinux boolean by
default, but not change its current state. Update docs to advise users
of this to avoid confusion when rsync distributors fail to run with
selinux in F27.

re #3347
https://pulp.plan.io/issues/3347