### PR TITLE
Support upload of tarball with incomplete layers.

### DIFF
--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -378,6 +378,13 @@ with the directory contents created by ``skopeo copy``::
 
     $ cd existingemptydirectory/ && tar -cvf ../image-name.tar * && cd ..
 
+
+.. note::
+
+    The tarball is only required to contain blob files for layers referenced in the manifest if they
+    are not already contained in the specified repository. Blob files included in the tarball that are
+    already contained in the repository will be ignored.
+
 Then create a Pulp repository and run an upload command with ``pulp-admin``::
 
     $ pulp-admin docker repo create --repo-id=schema2

--- a/docs/user-guide/release-notes/3.2.x.rst
+++ b/docs/user-guide/release-notes/3.2.x.rst
@@ -1,0 +1,9 @@
+3.2 Release Notes
+=================
+
+3.2.0
+-----
+
+Blob files for layers referenced in the manifest of an uploaded tarball no longer need to be
+included in the tarball if they are already contained in the specified repository. Blob files
+included in the tarball that are already contained in the repository will be ignored.

--- a/docs/user-guide/release-notes/index.rst
+++ b/docs/user-guide/release-notes/index.rst
@@ -6,6 +6,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   3.2.x
    3.1.x
    3.0.x
    2.4.x


### PR DESCRIPTION
https://pulp.plan.io/issues/3497

Support upload of tarball with incomplete layers.

The `AddUnits.process_main()` is doing too much and needs to be refactored but outside the scope of this story.  Copied and pasted most of the added unit test as well.