### PR TITLE
Fix upload issue with embeddedmanifests

### DIFF
--- a/plugins/pulp_docker/plugins/importers/upload.py
+++ b/plugins/pulp_docker/plugins/importers/upload.py
@@ -196,7 +196,9 @@ class AddManifestList(PluginStep):
         transfer_repo = self.get_repo()
 
         #  Ensure that all referenced manifests are already in repository.
-        manifest_digests = set(manifest_list_instance.manifests)
+        manifest_digests = set(
+            [manifest.digest for manifest in manifest_list_instance['manifests']]
+        )
         qs = models.Manifest.objects.filter(
             digest__in=sorted(manifest_digests)).only('id', 'digest')
         known_manifests = dict((manifest['digest'], manifest['id']) for manifest in qs)


### PR DESCRIPTION
closes #3904
https://pulp.plan.io/issues/3904

I can't get crane to work, so the pulpsmash tests keep failing with
```
requests.exceptions.ConnectionError: HTTPConnectionPool(host='192.168.121.29', port=5000): Max retries exceeded with url: /v2/d55d3ced-d1cf-4c3d-b9a7-0a2777657cbe/manifests/latest (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7fb79a148940>: Failed to establish a new connection: [Errno 111] Connection refused',))
```

But I did manually test this change with 
`pulp-admin docker repo uploads upload --repo-id=busybox -f manifest_list.json`

where the manifest_list.json is:
```
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 527,
         "digest": "sha256:c7b0a24019b0e6eda714ec0fa137ad42bc44a754d9cea17d14fba3a80ccc1ee4",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 527,
         "digest": "sha256:a4822cb5d974f375f84c0a534cd6fdbc983ffefba1eeab16d09ccb12028b928c",
         "platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v5"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 527,
         "digest": "sha256:883b6e95daad4c7ad5f86a0124de945bacc613da3ee0ca17bed6a2e9b848ce27",
         "platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v7"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 527,
         "digest": "sha256:08c10dde83399a3ff83e21feb679b3942dbe8aa652d49c144e8e544696558d7f",
         "platform": {
            "architecture": "arm64",
            "os": "linux",
            "variant": "v8"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 527,
         "digest": "sha256:60282b56cd5b4bcf3c160e124782b740bcde374a667a1f5f9164b243ae05753c",
         "platform": {
            "architecture": "386",
            "os": "linux"
         }
      }
   ]
}
```