### PR TITLE
docker pull fails with unexpected end of JSON input

### DIFF
--- a/common/pulp_docker/common/tarutils.py
+++ b/common/pulp_docker/common/tarutils.py
@@ -3,6 +3,8 @@ import json
 import os
 import tarfile
 
+from collections import OrderedDict
+
 
 def get_metadata(tarfile_path):
     """
@@ -131,7 +133,8 @@ def get_image_manifest(tarfile_path):
         for member in archive.getmembers():
             # find the "manifest.json" file
             if os.path.basename(member.path) == 'manifest.json':
-                image_manifest = json.load(archive.extractfile(member))
+                image_manifest = json.load(archive.extractfile(member),
+                                           object_pairs_hook=OrderedDict)
                 break
 
     return image_manifest

--- a/plugins/pulp_docker/plugins/importers/upload.py
+++ b/plugins/pulp_docker/plugins/importers/upload.py
@@ -236,7 +236,8 @@ class ProcessManifest(PluginStep):
         """
         Pull the image manifest out of the tar file
         """
-        image_manifest = json.dumps(tarutils.get_image_manifest(self.parent.file_path))
+        image_manifest = json.dumps(tarutils.get_image_manifest(self.parent.file_path),
+                                    separators=(',', ':'))
         digest = models.UnitMixin.calculate_digest(image_manifest)
         with open(os.path.join(self.get_working_dir(), digest), 'w') as manifest_file:
             manifest_file.write(image_manifest)


### PR DESCRIPTION
closes #3910
https://pulp.plan.io/issues/3910

json.load and json.dump reorderes manifest file.
The "signatures" field is supposed to be at the end of the JSON, because docker while
stripping the signatures operates on the raw bytes of the data, without regard to JSON
structure.