### PR TITLE
Adds models, viewsets, and serializers needed for publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ dist: xenial
 language: python
 python:
     # python versions used in el7 SCL & supported fedora
-    - "3.5"
     - "3.6"
     - "3.7"
 env:

--- a/pulp_docker/app/models.py
+++ b/pulp_docker/app/models.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 from django.db import models
 
-from pulpcore.plugin.models import Content, Remote, Publisher
+from pulpcore.plugin.models import BaseDistribution, Content, Remote, Publisher
 
 
 logger = getLogger(__name__)
@@ -192,3 +192,14 @@ class DockerRemote(Remote):
     """
 
     TYPE = 'docker'
+
+
+class DockerDistribution(BaseDistribution):
+    """
+    A docker distribution defines how a publication is distributed by Pulp's webserver.
+
+    All docker distributions are made available at /v2/<base_path>/.
+    """
+
+    class Meta:
+        default_related_name = 'docker_distributions'

--- a/pulp_docker/app/tasks/publishing.py
+++ b/pulp_docker/app/tasks/publishing.py
@@ -3,12 +3,8 @@ from gettext import gettext as _
 
 from pulpcore.plugin.models import (  # noqa
     RepositoryVersion,
-    Publication,
-    PublishedArtifact,
-    PublishedMetadata,
-    RemoteArtifact
+    Publication
 )
-from pulpcore.plugin.tasking import WorkingDirectory
 
 from pulp_docker.app.models import DockerPublisher
 
@@ -32,25 +28,7 @@ def publish(publisher_pk, repository_version_pk):
         ver=repository_version.number,
         pub=publisher.name
     ))
-    with WorkingDirectory():
-        with Publication.create(repository_version, publisher) as publication:
-            # Write any Artifacts (files) to the file system, and the database.
-            #
-            # artifact = YourArtifactWriter.write(relative_path)
-            # published_artifact = PublishedArtifact(
-            #     relative_path=artifact.relative_path,
-            #     publication=publication,
-            #     content_artifact=artifact)
-            # published_artifact.save()
 
-            # Write any metadata files to the file system, and the database.
-            #
-            # metadata = YourMetadataWriter.write(relative_path)
-            # metadata = PublishedMetadata(
-            #     relative_path=os.path.basename(manifest.relative_path),
-            #     publication=publication,
-            #     file=File(open(manifest.relative_path, 'rb')))
-            # metadata.save()
-            pass
+    publication = Publication.create(repository_version, publisher, pass_through=True)
 
     log.info(_('Publication: {publication} created').format(publication.pk))

--- a/pulp_docker/app/viewsets.py
+++ b/pulp_docker/app/viewsets.py
@@ -7,24 +7,24 @@ Check `Plugin Writer's Guide`_ for more details.
 
 from drf_yasg.utils import swagger_auto_schema
 
-from pulpcore.plugin import viewsets as core
 from pulpcore.plugin.serializers import (
     AsyncOperationResponseSerializer,
     RepositoryPublishURLSerializer,
     RepositorySyncURLSerializer,
 )
 from pulpcore.plugin.tasking import enqueue_with_reservation
+from pulpcore.plugin.viewsets import (
+    RemoteViewSet,
+    OperationPostponedResponse,
+    PublisherViewSet)
 from rest_framework.decorators import detail_route
 
 from . import models, serializers, tasks
 
 
-class DockerRemoteViewSet(core.RemoteViewSet):
+class DockerRemoteViewSet(RemoteViewSet):
     """
     A ViewSet for DockerRemote.
-
-    Similar to the DockerContentViewSet above, define endpoint_name,
-    queryset and serializer, at a minimum.
     """
 
     endpoint_name = 'docker'
@@ -56,15 +56,12 @@ class DockerRemoteViewSet(core.RemoteViewSet):
                 'repository_pk': repository.pk
             }
         )
-        return core.OperationPostponedResponse(result, request)
+        return OperationPostponedResponse(result, request)
 
 
-class DockerPublisherViewSet(core.PublisherViewSet):
+class DockerPublisherViewSet(PublisherViewSet):
     """
     A ViewSet for DockerPublisher.
-
-    Similar to the DockerContentViewSet above, define endpoint_name,
-    queryset and serializer, at a minimum.
     """
 
     endpoint_name = 'docker'
@@ -101,4 +98,4 @@ class DockerPublisherViewSet(core.PublisherViewSet):
                 'repository_version_pk': str(repository_version.pk)
             }
         )
-        return core.OperationPostponedResponse(result, request)
+        return OperationPostponedResponse(result, request)


### PR DESCRIPTION
This patch also updates the publish task to simply create a pass_through Publication.

closes: #3991
https://pulp.plan.io/issues/3991

closes: #3992
https://pulp.plan.io/issues/3992