### PR TITLE
Remove non-unique tag names during sync

### DIFF
--- a/pulp_docker/app/models.py
+++ b/pulp_docker/app/models.py
@@ -154,23 +154,15 @@ class ManifestListManifest(models.Model):
         ManifestList, related_name='manifest_lists', on_delete=models.CASCADE)
 
 
-class Tag(Content):
+class ManifestTag(Content):
     """
-    A docker tag.
-
-    Each tag will reference either a Manifest or a ManifestList.
-    A repository may contain tags with duplicate names provided each tag references
-    a different type of object (Manifest|ManifestList).  This uniqueness is enforced
-    programmatically.
-
-    This content has no artifacts.
+    A tagged Manifest.
 
     Fields:
         name (models.CharField): The tag name.
 
     Relations:
         manifest (models.ForeignKey): A referenced Manifest.
-        manifest_list (models.ForeignKey): A referenced ManifestList.
 
     """
 
@@ -179,13 +171,35 @@ class Tag(Content):
     name = models.CharField(max_length=255, db_index=True)
 
     manifest = models.ForeignKey(
-        ImageManifest, null=True, related_name='tags', on_delete=models.CASCADE)
-    manifest_list = models.ForeignKey(
-        ManifestList, null=True, related_name='tags', on_delete=models.CASCADE)
+        ImageManifest, null=True, related_name='manifest_tags', on_delete=models.CASCADE)
 
     class Meta:
         unique_together = (
             ('name', 'manifest'),
+        )
+
+
+class ManifestListTag(Content):
+    """
+    A tagged Manifest List.
+
+    Fields:
+        name (models.CharField): The tag name.
+
+    Relations:
+        manifest_list (models.ForeignKey): A referenced Manifest List.
+
+    """
+
+    TYPE = 'tag'
+
+    name = models.CharField(max_length=255, db_index=True)
+
+    manifest_list = models.ForeignKey(
+        ManifestList, null=True, related_name='manifest_list_tags', on_delete=models.CASCADE)
+
+    class Meta:
+        unique_together = (
             ('name', 'manifest_list'),
         )
 

--- a/pulp_docker/app/models.py
+++ b/pulp_docker/app/models.py
@@ -166,7 +166,7 @@ class ManifestTag(Content):
 
     """
 
-    TYPE = 'tag'
+    TYPE = 'manifest-tag'
 
     name = models.CharField(max_length=255, db_index=True)
 
@@ -191,7 +191,7 @@ class ManifestListTag(Content):
 
     """
 
-    TYPE = 'tag'
+    TYPE = 'manifest-list-tag'
 
     name = models.CharField(max_length=255, db_index=True)
 

--- a/pulp_docker/app/tasks/sync_stages.py
+++ b/pulp_docker/app/tasks/sync_stages.py
@@ -25,6 +25,7 @@ class TempTag:
     """
 
     def __init__(self, name):
+        """Make a temp tag."""
         self.name = name
 
 

--- a/pulp_docker/app/tasks/sync_stages.py
+++ b/pulp_docker/app/tasks/sync_stages.py
@@ -6,8 +6,9 @@ from django.db import IntegrityError
 from pulpcore.plugin.models import Artifact
 from pulpcore.plugin.stages import DeclarativeArtifact, DeclarativeContent, Stage
 
-from pulp_docker.app.models import (ImageManifest, MEDIA_TYPE, ManifestBlob,
-                                    ManifestList, Tag, BlobManifestBlob, ManifestListManifest)
+from pulp_docker.app.models import (ImageManifest, MEDIA_TYPE, ManifestBlob, ManifestTag,
+                                    ManifestList, ManifestListTag, BlobManifestBlob,
+                                    ManifestListManifest)
 
 
 log = logging.getLogger(__name__)
@@ -16,6 +17,15 @@ log = logging.getLogger(__name__)
 V2_ACCEPT_HEADERS = {
     'accept': ','.join([MEDIA_TYPE.MANIFEST_V2, MEDIA_TYPE.MANIFEST_LIST])
 }
+
+
+class TempTag:
+    """
+    This is a pseudo Tag that will either become a ManifestTag or a ManifestListTag.
+    """
+
+    def __init__(self, name):
+        self.name = name
 
 
 class TagListStage(Stage):
@@ -72,7 +82,7 @@ class TagListStage(Stage):
             tag=tag_name,
         )
         url = urljoin(self.remote.url, relative_url)
-        tag = Tag(name=tag_name)
+        tag = TempTag(name=tag_name)
         manifest_artifact = Artifact()
         da = DeclarativeArtifact(
             artifact=manifest_artifact,
@@ -127,7 +137,7 @@ class ProcessContentStage(Stage):
                 raw = content_file.read()
             content_data = json.loads(raw)
 
-            if type(dc.content) is Tag:
+            if type(dc.content) is TempTag:
                 if content_data.get('mediaType') == MEDIA_TYPE.MANIFEST_LIST:
                     await self.create_and_process_tagged_manifest_list(dc, content_data, out_q)
                     await out_q.put(dc)
@@ -164,7 +174,7 @@ class ProcessContentStage(Stage):
             manifest_list_data (dict): Data about a ManifestList
             out_q (asyncio.Queue): Queue to put created ManifestList and ImageManifest dcs.
         """
-        assert type(tag_dc.content) is Tag
+        tag_dc.content = ManifestListTag(name=tag_dc.content.name)
         digest = "sha256:{digest}".format(digest=tag_dc.d_artifacts[0].artifact.sha256)
         relative_url = '/v2/{name}/manifests/{digest}'.format(
             name=self.remote.namespaced_upstream_name,
@@ -200,6 +210,7 @@ class ProcessContentStage(Stage):
             manifest_data (dict): Data about a single new ImageManifest.
             out_q (asyncio.Queue): Queue to put created ImageManifest dcs and Blob dcs.
         """
+        tag_dc.content = ManifestTag(name=tag_dc.content.name)
         manifest = ImageManifest(
             digest=tag_dc.d_artifacts[0].artifact.sha256,
             schema_version=manifest_data['schemaVersion'],
@@ -348,13 +359,14 @@ class InterrelateContent(Stage):
         """
         related_dc = dc.extra_data.get('relation')
         assert related_dc is not None
-        if type(related_dc.content) is Tag:
+        if type(related_dc.content) is ManifestTag:
             assert related_dc.content.manifest is None
             related_dc.content.manifest = dc.content
             try:
                 related_dc.content.save()
             except IntegrityError:
-                existing_tag = Tag.objects.get(name=related_dc.content.name, manifest=dc.content)
+                existing_tag = ManifestTag.objects.get(name=related_dc.content.name,
+                                                       manifest=dc.content)
                 related_dc.content = existing_tag
         elif type(related_dc.content) is ManifestList:
             thru = ManifestListManifest(manifest_list=related_dc.content, manifest=dc.content)
@@ -371,11 +383,12 @@ class InterrelateContent(Stage):
             dc (pulpcore.plugin.stages.DeclarativeContent): dc for a ManifestList
         """
         related_dc = dc.extra_data.get('relation')
-        assert type(related_dc.content) is Tag
+        assert type(related_dc.content) is ManifestListTag
         assert related_dc.content.manifest_list is None
         related_dc.content.manifest_list = dc.content
         try:
             related_dc.content.save()
         except IntegrityError:
-            existing_tag = Tag.objects.get(name=related_dc.content.name, manifest_list=dc.content)
+            existing_tag = ManifestListTag.objects.get(name=related_dc.content.name,
+                                                       manifest_list=dc.content)
             related_dc.content = existing_tag

--- a/pulp_docker/app/views.py
+++ b/pulp_docker/app/views.py
@@ -14,7 +14,7 @@ from wsgiref.util import FileWrapper
 
 from pulpcore.plugin.models import ContentArtifact
 
-from pulp_docker.app.models import DockerDistribution, Tag
+from pulp_docker.app.models import DockerDistribution, ManifestTag, ManifestListTag
 
 from rest_framework.negotiation import BaseContentNegotiation
 from rest_framework import response, views
@@ -222,6 +222,6 @@ class TagsListView(views.APIView):
         tags = {'name': path, 'tags': []}
         for c in distribution.publication.repository_version.content:
             c = c.cast()
-            if isinstance(c, Tag):
+            if isinstance(c, ManifestTag) or isinstance(c, ManifestListTag):
                 tags['tags'].append(c.name)
         return response.Response(tags)

--- a/pulp_docker/app/views.py
+++ b/pulp_docker/app/views.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 from gettext import gettext as _
@@ -14,10 +15,13 @@ from wsgiref.util import FileWrapper
 
 from pulpcore.plugin.models import ContentArtifact
 
-from pulp_docker.app.models import DockerDistribution, ManifestTag, ManifestListTag
+from pulp_docker.app.models import DockerDistribution, ManifestTag, ManifestListTag, MEDIA_TYPE
 
 from rest_framework.negotiation import BaseContentNegotiation
 from rest_framework import response, views
+
+
+log = logging.getLogger(__name__)
 
 
 class PathNotResolved(Exception):
@@ -153,25 +157,45 @@ class TagView(views.APIView, ServeContentMixin):
         Return a response to the "GET" action.
         """
         distribution = get_object_or_404(DockerDistribution, base_path=path)
-        try:
-            ca = ContentArtifact.objects.get(
-                content__in=distribution.publication.repository_version.content,
-                relative_path=tag_name)
-            content = ca.content.cast()
-            if content.manifest:
-                headers = {'Content-Type': content.manifest.media_type}
+
+        if MEDIA_TYPE.MANIFEST_LIST in request.META['HTTP_ACCEPT']:
+            try:
+                tag = ManifestListTag.objects.get(
+                    pk__in=distribution.publication.repository_version.content,
+                    name=tag_name
+                )
+            # If there is no manifest list tag, try again with manifest tag.
+            except ObjectDoesNotExist:
+                pass
             else:
-                headers = {'Content-Type': content.manifest_list.media_type}
-        except ObjectDoesNotExist:
-            pass
+                headers = {'Content-Type': MEDIA_TYPE.MANIFEST_LIST}
+                return self._dispatch_tag(tag, path, headers)
+
+        if MEDIA_TYPE.MANIFEST_V2 in request.META['HTTP_ACCEPT']:
+            try:
+                tag = ManifestTag.objects.get(
+                    pk__in=distribution.publication.repository_version.content,
+                    name=tag_name
+                )
+            except ObjectDoesNotExist:
+                pass
+            else:
+                headers = {'Content-Type': MEDIA_TYPE.MANIFEST_V2}
+                return self._dispatch_tag(tag, path, headers)
+
         else:
-            artifact = ca.artifact
-            if artifact:
-                return self._dispatch(artifact.file.name, headers)
-            else:
-                raise ArtifactNotFound(path)
+            # This is where we could eventually support on-the-fly conversion to schema 1.
+            log.warn("Client does not accept Docker V2 Schema 2 and is not currently supported.")
 
         raise PathNotResolved(path)
+
+    def _dispatch_tag(self, tag, path, headers):
+        # Tags should only ever have 1 artifact.
+        artifact = tag.artifacts.first()
+        if not artifact:
+            raise ArtifactNotFound(path)
+        else:
+            return self._dispatch(artifact.file.name, headers)
 
 
 class BlobManifestView(views.APIView, ServeContentMixin):
@@ -219,9 +243,9 @@ class TagsListView(views.APIView):
         Return JSON of all tags in this repo.
         """
         distribution = get_object_or_404(DockerDistribution, base_path=path)
-        tags = {'name': path, 'tags': []}
+        tags = {'name': path, 'tags': set()}
         for c in distribution.publication.repository_version.content:
             c = c.cast()
             if isinstance(c, ManifestTag) or isinstance(c, ManifestListTag):
-                tags['tags'].append(c.name)
+                tags['tags'].add(c.name)
         return response.Response(tags)


### PR DESCRIPTION
When syncing, if a tag name references a different manifest/manifest
list it must be removed from the repo. To do this simply, it was more
convinient to split the Tag model into ManifestTag and ManifestListTag.

https://pulp.plan.io/issues/4172
fixes #4172