### PR TITLE
Create Serializers and Viewsets for Content

### DIFF
--- a/pulp_docker/app/models.py
+++ b/pulp_docker/app/models.py
@@ -22,7 +22,20 @@ MEDIA_TYPE = SimpleNamespace(
 )
 
 
-class ManifestBlob(Content):
+class SingleArtifact:
+    """
+    Mixin for Content with only 1 artifact.
+    """
+
+    @property
+    def _artifact(self):
+        """
+        Return the artifact (there is only one for this content type).
+        """
+        return self._artifacts.get()
+
+
+class ManifestBlob(Content, SingleArtifact):
     """
     A blob defined within a manifest.
 
@@ -51,7 +64,7 @@ class ManifestBlob(Content):
         unique_together = ('digest',)
 
 
-class ImageManifest(Content):
+class ImageManifest(Content, SingleArtifact):
     """
     A docker manifest.
 
@@ -82,7 +95,7 @@ class ImageManifest(Content):
         unique_together = ('digest',)
 
 
-class ManifestList(Content):
+class ManifestList(Content, SingleArtifact):
     """
     A manifest list.
 
@@ -160,7 +173,7 @@ class ManifestListManifest(models.Model):
         unique_together = ('manifest', 'manifest_list')
 
 
-class ManifestTag(Content):
+class ManifestTag(Content, SingleArtifact):
     """
     A tagged Manifest.
 
@@ -185,7 +198,7 @@ class ManifestTag(Content):
         )
 
 
-class ManifestListTag(Content):
+class ManifestListTag(Content, SingleArtifact):
     """
     A tagged Manifest List.
 

--- a/pulp_docker/app/models.py
+++ b/pulp_docker/app/models.py
@@ -123,6 +123,9 @@ class BlobManifestBlob(models.Model):
     manifest_blob = models.ForeignKey(
         ManifestBlob, related_name='manifest_blobs', on_delete=models.CASCADE)
 
+    class Meta:
+        unique_together = ('manifest', 'manifest_blob')
+
 
 class ManifestListManifest(models.Model):
     """
@@ -152,6 +155,9 @@ class ManifestListManifest(models.Model):
         ImageManifest, related_name='manifests', on_delete=models.CASCADE)
     manifest_list = models.ForeignKey(
         ManifestList, related_name='manifest_lists', on_delete=models.CASCADE)
+
+    class Meta:
+        unique_together = ('manifest', 'manifest_list')
 
 
 class ManifestTag(Content):

--- a/pulp_docker/app/serializers.py
+++ b/pulp_docker/app/serializers.py
@@ -19,11 +19,6 @@ class MinimalArtifactSerializer(platform.ArtifactSerializer):
 
     We overrided the platform serializer because it does not include size, and includes digest.
     Since digest is a field on the content units, it would be redundant.
-
-    Even though Docker content can only have 1 Artifact, this field should be used with
-    `many=True` because the Artifact is related with the ContentArtifact through table, and when
-    the same Artifact is served at multiple relative_paths, there are multiple associations of
-    between a given Content and Artifact.
     """
 
     class Meta:
@@ -43,12 +38,12 @@ class ManifestListTagSerializer(platform.ContentSerializer):
         view_name='docker-manifest-lists-detail',
         queryset=models.ManifestList.objects.all()
     )
-    artifacts = MinimalArtifactSerializer(many=True, help_text="File related to this content")
+    _artifact = MinimalArtifactSerializer(many=False, help_text="File related to this content")
 
     class Meta:
         fields = tuple(
             set(platform.ContentSerializer.Meta.fields) - {'_artifacts'}
-        ) + ('name', 'manifest_list', 'artifacts')
+        ) + ('name', 'manifest_list', '_artifact')
         model = models.ManifestListTag
 
 
@@ -64,12 +59,12 @@ class ManifestTagSerializer(platform.ContentSerializer):
         view_name='docker-manifests-detail',
         queryset=models.ImageManifest.objects.all()
     )
-    artifacts = MinimalArtifactSerializer(many=True, help_text="File related to this content")
+    _artifact = MinimalArtifactSerializer(many=False, help_text="File related to this content")
 
     class Meta:
         fields = tuple(
             set(platform.ContentSerializer.Meta.fields) - {'_artifacts'}
-        ) + ('name', 'manifest', 'artifacts')
+        ) + ('name', 'manifest', '_artifact')
         model = models.ManifestTag
 
 
@@ -87,12 +82,12 @@ class ManifestListSerializer(platform.ContentSerializer):
         view_name='docker-manifests-detail',
         queryset=models.ImageManifest.objects.all()
     )
-    artifacts = MinimalArtifactSerializer(many=True, help_text="File related to this content")
+    _artifact = MinimalArtifactSerializer(many=False, help_text="File related to this content")
 
     class Meta:
         fields = tuple(
             set(platform.ContentSerializer.Meta.fields) - {'_artifacts'}
-        ) + ('digest', 'schema_version', 'media_type', 'manifests', 'artifacts')
+        ) + ('digest', 'schema_version', 'media_type', 'manifests', '_artifact')
         model = models.ManifestList
 
 
@@ -116,12 +111,12 @@ class ManifestSerializer(platform.ContentSerializer):
         view_name='docker-blobs-detail',
         queryset=models.ManifestBlob.objects.all()
     )
-    artifacts = MinimalArtifactSerializer(many=True, help_text="File related to this content")
+    _artifact = MinimalArtifactSerializer(many=False, help_text="File related to this content")
 
     class Meta:
         fields = tuple(
             set(platform.ContentSerializer.Meta.fields) - {'_artifacts'}
-        ) + ('digest', 'schema_version', 'media_type', 'blobs', 'config_blob', 'artifacts')
+        ) + ('digest', 'schema_version', 'media_type', 'blobs', 'config_blob', '_artifact')
         model = models.ImageManifest
 
 
@@ -132,12 +127,12 @@ class BlobSerializer(platform.ContentSerializer):
 
     digest = serializers.CharField(help_text="sha256 of the Blob file")
     media_type = serializers.CharField(help_text="Docker media type of the file")
-    artifacts = MinimalArtifactSerializer(many=True, help_text="File related to this content")
+    _artifact = MinimalArtifactSerializer(many=False, help_text="File related to this content")
 
     class Meta:
         fields = tuple(
             set(platform.ContentSerializer.Meta.fields) - {'_artifacts'}
-        ) + ('digest', 'media_type', 'artifacts')
+        ) + ('digest', 'media_type', '_artifact')
         model = models.ManifestBlob
 
 

--- a/pulp_docker/app/viewsets.py
+++ b/pulp_docker/app/viewsets.py
@@ -5,6 +5,7 @@ Check `Plugin Writer's Guide`_ for more details.
     http://docs.pulpproject.org/en/3.0/nightly/plugins/plugin-writer/index.html
 """
 
+from django.db import transaction
 from drf_yasg.utils import swagger_auto_schema
 
 from pulpcore.plugin.serializers import (
@@ -14,6 +15,7 @@ from pulpcore.plugin.serializers import (
 )
 from pulpcore.plugin.tasking import enqueue_with_reservation
 from pulpcore.plugin.viewsets import (
+    ContentViewSet,
     NamedModelViewSet,
     RemoteViewSet,
     OperationPostponedResponse,
@@ -22,6 +24,91 @@ from rest_framework.decorators import detail_route
 from rest_framework import mixins
 
 from . import models, serializers, tasks
+
+
+class ManifestListTagViewSet(ContentViewSet):
+    """
+    ViewSet for ManifestListTag.
+    """
+
+    endpoint_name = 'docker/manifest-list-tags'
+    queryset = models.ManifestListTag.objects.all()
+    serializer_class = serializers.ManifestListTagSerializer
+
+    @transaction.atomic
+    def create(self, request):
+        """
+        Create a new ManifestListTag from a request.
+        """
+        raise NotImplementedError()
+
+
+class ManifestTagViewSet(ContentViewSet):
+    """
+    ViewSet for ManifestTag.
+    """
+
+    endpoint_name = 'docker/manifest-tags'
+    queryset = models.ManifestTag.objects.all()
+    serializer_class = serializers.ManifestTagSerializer
+
+    @transaction.atomic
+    def create(self, request):
+        """
+        Create a new ManifestTag from a request.
+        """
+        raise NotImplementedError()
+
+
+class ManifestListViewSet(ContentViewSet):
+    """
+    ViewSet for ManifestList.
+    """
+
+    endpoint_name = 'docker/manifest-lists'
+    queryset = models.ManifestList.objects.all()
+    serializer_class = serializers.ManifestListSerializer
+
+    @transaction.atomic
+    def create(self, request):
+        """
+        Create a new ManifestList from a request.
+        """
+        raise NotImplementedError()
+
+
+class ManifestViewSet(ContentViewSet):
+    """
+    ViewSet for Manifest.
+    """
+
+    endpoint_name = 'docker/manifests'
+    queryset = models.ImageManifest.objects.all()
+    serializer_class = serializers.ManifestSerializer
+
+    @transaction.atomic
+    def create(self, request):
+        """
+        Create a new Manifest from a request.
+        """
+        raise NotImplementedError()
+
+
+class BlobViewSet(ContentViewSet):
+    """
+    ViewSet for ManifestBlobs.
+    """
+
+    endpoint_name = 'docker/blobs'
+    queryset = models.ManifestBlob.objects.all()
+    serializer_class = serializers.BlobSerializer
+
+    @transaction.atomic
+    def create(self, request):
+        """
+        Create a new ManifestBlob from a request.
+        """
+        raise NotImplementedError()
 
 
 class DockerRemoteViewSet(RemoteViewSet):


### PR DESCRIPTION
This commit leaves POST (create) unimplemented as well as Filters which
are each complex enough that they warrent a separate issue and PR.

https://pulp.plan.io/issues/3989
fixes #3989