### PR TITLE
Add policy to remote tests

### DIFF
--- a/pulp_docker/tests/functional/api/test_crud_remotes.py
+++ b/pulp_docker/tests/functional/api/test_crud_remotes.py
@@ -7,7 +7,7 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, utils
 
-from pulp_docker.tests.functional.constants import DOCKER_REMOTE_PATH
+from pulp_docker.tests.functional.constants import DOCKER_REMOTE_PATH, DOWNLOAD_POLICIES
 from pulp_docker.tests.functional.utils import skip_if, gen_docker_remote
 from pulp_docker.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 
@@ -126,6 +126,7 @@ def _gen_verbose_remote():
     attrs.update({
         'password': utils.uuid4(),
         'username': utils.uuid4(),
+        'policy': choice(DOWNLOAD_POLICIES),
         'validate': choice((False, True)),
     })
     return attrs

--- a/pulp_docker/tests/functional/constants.py
+++ b/pulp_docker/tests/functional/constants.py
@@ -2,6 +2,7 @@
 from urllib.parse import urljoin
 
 from pulp_smash.constants import PULP_FIXTURES_BASE_URL
+from pulp_smash.pulp3.constants import DOWNLOAD_POLICIES  # noqa:F401
 from pulp_smash.pulp3.constants import (
     BASE_PUBLISHER_PATH,
     BASE_REMOTE_PATH,

--- a/pulp_docker/tests/functional/utils.py
+++ b/pulp_docker/tests/functional/utils.py
@@ -81,7 +81,7 @@ def gen_docker_image_attrs(artifact):
     :returns: A semi-random dict for use in creating a content unit.
     """
     # FIXME: Add content specific metadata here.
-    return {'artifact': artifact['_href']}
+    return {'_artifact': artifact['_href']}
 
 
 def populate_pulp(cfg, url=DOCKER_FIXTURE_URL):


### PR DESCRIPTION
Update _gen_verbose_remote to add download policy field. Add constant
DOWNLOAD_POLICIES.

re #4182
https://pulp.plan.io/issues/4182