### PR TITLE
Simplify constant DOWNLOAD_POLICIES import

### DIFF
--- a/pulp_docker/tests/functional/api/test_crud_remotes.py
+++ b/pulp_docker/tests/functional/api/test_crud_remotes.py
@@ -6,8 +6,9 @@ import unittest
 from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, utils
+from pulp_smash.pulp3.constants import DOWNLOAD_POLICIES
 
-from pulp_docker.tests.functional.constants import DOCKER_REMOTE_PATH, DOWNLOAD_POLICIES
+from pulp_docker.tests.functional.constants import DOCKER_REMOTE_PATH
 from pulp_docker.tests.functional.utils import skip_if, gen_docker_remote
 from pulp_docker.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 

--- a/pulp_docker/tests/functional/constants.py
+++ b/pulp_docker/tests/functional/constants.py
@@ -2,7 +2,6 @@
 from urllib.parse import urljoin
 
 from pulp_smash.constants import PULP_FIXTURES_BASE_URL
-from pulp_smash.pulp3.constants import DOWNLOAD_POLICIES  # noqa:F401
 from pulp_smash.pulp3.constants import (
     BASE_PUBLISHER_PATH,
     BASE_REMOTE_PATH,


### PR DESCRIPTION
Simplify constnat `DOWNLOAD_POLICIES` to import from pulp-smash
directly. To be align with the same way that this is done in the other
plugins.

'[noissue]'