### PR TITLE
Updates test to handle changes to Distribution CUD operations

### DIFF
--- a/pulp_docker/tests/functional/api/test_download_content.py
+++ b/pulp_docker/tests/functional/api/test_download_content.py
@@ -80,7 +80,10 @@ class DownloadContentTestCase(unittest.TestCase):
         # Create a distribution.
         body = gen_distribution()
         body['publication'] = publication['_href']
-        distribution = client.post(DOCKER_DISTRIBUTION_PATH, body)
+        response_dict = client.post(DOCKER_DISTRIBUTION_PATH, body)
+        dist_task = client.get(response_dict['task'])
+        distribution_href = dist_task['created_resources'][0]
+        distribution = client.get(distribution_href)
         self.addCleanup(client.delete, distribution['_href'])
 
         # Get local checksums for content synced from remote registy


### PR DESCRIPTION
Create, update, and delete for Distributions were made asynchronous in:
pulp/pulpcore#6
in response to issue 3044:
https://pulp.plan.io/issues/3044
Because of these changes, tests that create distributions previously expected
this action to return a distribution but now receive a task so additional steps
were needed to retrieve the distribution from the created_resources of the task

Required PR: pulp/pulpcore#6

ref #3044
https://pulp.plan.io/issues/3044