### PR TITLE
Problem: DockerDistribution name field not validated correctly

### DIFF
--- a/pulp_docker/app/serializers.py
+++ b/pulp_docker/app/serializers.py
@@ -182,6 +182,15 @@ class DockerDistributionSerializer(BaseDistributionSerializer):
     _href = IdentityField(
         view_name='docker-distributions-detail'
     )
+    name = serializers.CharField(
+        help_text=_('A unique distribution name. Ex, `rawhide` and `stable`.'),
+        validators=[validators.MaxLengthValidator(
+            models.DockerDistribution._meta.get_field('name').max_length,
+            message=_('DockerDistribution name length must be less than {} characters').format(
+                models.DockerDistribution._meta.get_field('name').max_length
+            )),
+            UniqueValidator(queryset=models.DockerDistribution.objects.all())]
+    )
     base_path = serializers.CharField(
         help_text=_('The base (relative) path that identifies the registry path.'),
         validators=[validators.MaxLengthValidator(

--- a/pulp_docker/tests/functional/api/test_crud_distributions.py
+++ b/pulp_docker/tests/functional/api/test_crud_distributions.py
@@ -46,8 +46,6 @@ class CRUDDockerDistributionsTestCase(unittest.TestCase):
         See: `Pulp Smash #1055
         <https://github.com/PulpQE/pulp-smash/issues/1055>`_.
         """
-        if not selectors.bug_is_fixed(4600, self.cfg.pulp_version):
-            raise unittest.SkipTest('Issue 4599 is not resolved')
         body = gen_distribution()
         body['name'] = self.distribution['name']
         with self.assertRaises(HTTPError):
@@ -182,29 +180,21 @@ class DistributionBasePathTestCase(unittest.TestCase):
 
     def test_spaces(self):
         """Test that spaces can not be part of ``base_path``."""
-        if not selectors.bug_is_fixed(4600, self.cfg.pulp_version):
-            raise unittest.SkipTest('Issue 4599 is not resolved')
         self.try_create_distribution(base_path=utils.uuid4().replace('-', ' '))
         self.try_update_distribution(base_path=utils.uuid4().replace('-', ' '))
 
     def test_begin_slash(self):
         """Test that slash cannot be in the begin of ``base_path``."""
-        if not selectors.bug_is_fixed(4600, self.cfg.pulp_version):
-            raise unittest.SkipTest('Issue 4599 is not resolved')
         self.try_create_distribution(base_path='/' + utils.uuid4())
         self.try_update_distribution(base_path='/' + utils.uuid4())
 
     def test_end_slash(self):
         """Test that slash cannot be in the end of ``base_path``."""
-        if not selectors.bug_is_fixed(4600, self.cfg.pulp_version):
-            raise unittest.SkipTest('Issue 4599 is not resolved')
         self.try_create_distribution(base_path=utils.uuid4() + '/')
         self.try_update_distribution(base_path=utils.uuid4() + '/')
 
     def test_unique_base_path(self):
         """Test that ``base_path`` can not be duplicated."""
-        if not selectors.bug_is_fixed(4600, self.cfg.pulp_version):
-            raise unittest.SkipTest('Issue 4599 is not resolved')
         self.try_create_distribution(base_path=self.distribution['base_path'])
 
     def try_create_distribution(self, **kwargs):


### PR DESCRIPTION
Solution: Define the name field on the DockerDistribution serializer

The name field from the BaseDistribution serializer validates that the name doesn't collide
with any other Distributions.

closes: #4600
https://pulp.plan.io/issues/4600