### PR TITLE
Problem: docker plugin does not support lazy sync

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,15 @@ Create a repository ``foo``
 Create a new remote ``bar``
 ---------------------------
 
-``$ http POST http://localhost:24817/pulp/api/v3/remotes/docker/docker/ name='library/busybox' upstream_name='busybox' url='https://registry-1.docker.io'``
+Docker remotes can be configured with a ``policy``. The default value is ``immediate``. All
+manifests and blobs are downloaded and saved during a sync with the ``immediate`` policy. When a
+remote with an ``on_demand`` policy is used to sync a repository, only tags and manifests are
+downloaded. Blobs are only downloaded when they are requested for the first time by a client.
+The ``streamed`` policy does not ever save any blobs and simply streams them to the client
+with every request. ``on_demand`` and ``streamed`` policies can provide significant disk space
+savings.
+
+``$ http POST http://localhost:24817/pulp/api/v3/remotes/docker/docker/ name='library/busybox' upstream_name='busybox' url='https://registry-1.docker.io' policy='on_demand'``
 
 .. code:: json
 

--- a/pulp_docker/app/content.py
+++ b/pulp_docker/app/content.py
@@ -3,9 +3,10 @@ from aiohttp import web
 from pulpcore.content import app
 from pulp_docker.app.registry import Registry
 
+registry = Registry()
 
 app.add_routes([web.get('/v2/', Registry.serve_v2)])
-app.add_routes([web.get(r'/v2/{path:.+}/blobs/sha256:{digest:.+}', Registry.get_by_digest)])
-app.add_routes([web.get(r'/v2/{path:.+}/manifests/sha256:{digest:.+}', Registry.get_by_digest)])
-app.add_routes([web.get(r'/v2/{path:.+}/manifests/{tag_name}', Registry.get_tag)])
-app.add_routes([web.get(r'/v2/{path:.+}/tags/list', Registry.tags_list)])
+app.add_routes([web.get(r'/v2/{path:.+}/blobs/sha256:{digest:.+}', registry.get_by_digest)])
+app.add_routes([web.get(r'/v2/{path:.+}/manifests/sha256:{digest:.+}', registry.get_by_digest)])
+app.add_routes([web.get(r'/v2/{path:.+}/manifests/{tag_name}', registry.get_tag)])
+app.add_routes([web.get(r'/v2/{path:.+}/tags/list', registry.tags_list)])

--- a/pulp_docker/app/models.py
+++ b/pulp_docker/app/models.py
@@ -252,12 +252,22 @@ class DockerRemote(Remote):
             )
             return self._download_factory
 
-    def get_downloader(self, url, **kwargs):
+    def get_downloader(self, remote_artifact=None, url=None, **kwargs):
         """
-        Get a downloader for this url.
+        Get a downloader from either a RemoteArtifact or URL that is configured with this Remote.
+
+        This method accepts either `remote_artifact` or `url` but not both. At least one is
+        required. If neither or both are passed a ValueError is raised.
 
         Args:
-            url (str): URL to fetch from.
+            remote_artifact (:class:`~pulpcore.app.models.RemoteArtifact`): The RemoteArtifact to
+                download.
+            url (str): The URL to download.
+            kwargs (dict): This accepts the parameters of
+                :class:`~pulpcore.plugin.download.BaseDownloader`.
+
+        Raises:
+            ValueError: If neither remote_artifact and url are passed, or if both are passed.
 
         Returns:
             subclass of :class:`~pulpcore.plugin.download.BaseDownloader`: A downloader that
@@ -265,7 +275,7 @@ class DockerRemote(Remote):
 
         """
         kwargs['remote'] = self
-        return self.download_factory.build(url, **kwargs)
+        return super().get_downloader(remote_artifact=remote_artifact, url=url, **kwargs)
 
     @property
     def namespaced_upstream_name(self):

--- a/pulp_docker/app/registry.py
+++ b/pulp_docker/app/registry.py
@@ -2,16 +2,28 @@ import logging
 import os
 
 from aiohttp import web, web_exceptions
+from aiohttp.client_exceptions import ClientResponseError
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
+from django.db import IntegrityError, transaction
 from gettext import gettext as _
 from multidict import MultiDict
 
-from pulpcore.plugin.models import ContentArtifact
+from pulpcore.plugin.models import Artifact, ContentArtifact, Remote
 from pulp_docker.app.models import DockerDistribution, ManifestTag, ManifestListTag, MEDIA_TYPE
 
 
 log = logging.getLogger(__name__)
+
+
+HOP_BY_HOP_HEADERS = [
+    'connection',
+    'keep-alive',
+    'public',
+    'proxy-authenticate',
+    'transfer-encoding',
+    'upgrade',
+]
 
 
 class PathNotResolved(web_exceptions.HTTPNotFound):
@@ -41,6 +53,12 @@ class Registry:
     A set of handlers for the Docker v2 API.
     """
 
+    def __init__(self):
+        """
+        Initializes the Registry class.
+        """
+        self.distribution_model = DockerDistribution
+
     @staticmethod
     async def get_accepted_media_types(request):
         """
@@ -59,8 +77,7 @@ class Registry:
                 accepted_media_types.append(value.decode('UTF-8'))
         return accepted_media_types
 
-    @staticmethod
-    async def match_distribution(path):
+    async def match_distribution(self, path):
         """
         Match a distribution using a base path.
 
@@ -75,7 +92,7 @@ class Registry:
 
         """
         try:
-            return DockerDistribution.objects.get(base_path=path)
+            return self.distribution_model.objects.get(base_path=path)
         except ObjectDoesNotExist:
             log.debug(_('DockerDistribution not matched for {path}.').format(path=path))
             raise PathNotResolved(path)
@@ -114,13 +131,12 @@ class Registry:
         """
         return web.json_response({})
 
-    @staticmethod
-    async def tags_list(request):
+    async def tags_list(self, request):
         """
         Handler for Docker Registry v2 tags/list API.
         """
         path = request.match_info['path']
-        distribution = await Registry.match_distribution(path)
+        distribution = await self.match_distribution(path)
         tags = {'name': path, 'tags': set()}
         repository_version = distribution.get_repository_version()
         for c in repository_version.content:
@@ -130,8 +146,7 @@ class Registry:
         tags['tags'] = list(tags['tags'])
         return web.json_response(tags)
 
-    @staticmethod
-    async def get_tag(request):
+    async def get_tag(self, request):
         """
         Match the path and stream either Manifest or ManifestList.
 
@@ -149,7 +164,7 @@ class Registry:
         """
         path = request.match_info['path']
         tag_name = request.match_info['tag_name']
-        distribution = await Registry.match_distribution(path)
+        distribution = await self.match_distribution(path)
         repository_version = distribution.get_repository_version()
         accepted_media_types = await Registry.get_accepted_media_types(request)
         if MEDIA_TYPE.MANIFEST_LIST in accepted_media_types:
@@ -205,14 +220,13 @@ class Registry:
             return await Registry._dispatch(os.path.join(settings.MEDIA_ROOT, artifact.file.name),
                                             response_headers)
 
-    @staticmethod
-    async def get_by_digest(request):
+    async def get_by_digest(self, request):
         """
         Return a response to the "GET" action.
         """
         path = request.match_info['path']
         digest = "sha256:{digest}".format(digest=request.match_info['digest'])
-        distribution = await Registry.match_distribution(path)
+        distribution = await self.match_distribution(path)
         repository_version = distribution.get_repository_version()
         log.info(digest)
         try:
@@ -228,4 +242,153 @@ class Registry:
                                                              artifact.file.name),
                                                 headers)
             else:
-                raise ArtifactNotFound(path)
+                return await self._stream_content_artifact(request, web.StreamResponse(), ca)
+
+    async def _stream_content_artifact(self, request, response, content_artifact):
+        """
+        Stream and optionally save a ContentArtifact by requesting it using the associated remote.
+
+        If a fatal download failure occurs while downloading and there are additional
+        :class:`~pulpcore.plugin.models.RemoteArtifact` objects associated with the
+        :class:`~pulpcore.plugin.models.ContentArtifact` they will also be tried. If all
+        :class:`~pulpcore.plugin.models.RemoteArtifact` downloads raise exceptions, an HTTP 502
+        error is returned to the client.
+
+        Args:
+            request(:class:`~aiohttp.web.Request`): The request to prepare a response for.
+            response (:class:`~aiohttp.web.StreamResponse`): The response to stream data to.
+            content_artifact (:class:`~pulpcore.plugin.models.ContentArtifact`): The ContentArtifact
+                to fetch and then stream back to the client
+
+        Raises:
+            :class:`~aiohttp.web.HTTPNotFound` when no
+                :class:`~pulpcore.plugin.models.RemoteArtifact` objects associated with the
+                :class:`~pulpcore.plugin.models.ContentArtifact` returned the binary data needed for
+                the client.
+
+        """
+        for remote_artifact in content_artifact.remoteartifact_set.all():
+            try:
+                response = await self._stream_remote_artifact(request, response, remote_artifact)
+
+            except ClientResponseError:
+                continue
+
+        raise web_exceptions.HTTPNotFound()
+
+    async def _stream_remote_artifact(self, request, response, remote_artifact):
+        """
+        Stream and save a RemoteArtifact.
+
+        Args:
+            request(:class:`~aiohttp.web.Request`): The request to prepare a response for.
+            response (:class:`~aiohttp.web.StreamResponse`): The response to stream data to.
+            content_artifact (:class:`~pulpcore.plugin.models.ContentArtifact`): The ContentArtifact
+                to fetch and then stream back to the client
+
+        Raises:
+            :class:`~aiohttp.web.HTTPNotFound` when no
+                :class:`~pulpcore.plugin.models.RemoteArtifact` objects associated with the
+                :class:`~pulpcore.plugin.models.ContentArtifact` returned the binary data needed for
+                the client.
+
+        """
+        remote = remote_artifact.remote.cast()
+
+        async def handle_headers(headers):
+            for name, value in headers.items():
+                if name.lower() in HOP_BY_HOP_HEADERS:
+                    continue
+                response.headers[name] = value
+            await response.prepare(request)
+
+        async def handle_data(data):
+            await response.write(data)
+            if remote.policy != Remote.STREAMED:
+                await original_handle_data(data)
+
+        async def finalize():
+            if remote.policy != Remote.STREAMED:
+                await original_finalize()
+
+        repo_name = remote.namespaced_upstream_name
+        downloader = remote.get_downloader(remote_artifact=remote_artifact,
+                                           headers_ready_callback=handle_headers)
+        original_handle_data = downloader.handle_data
+        downloader.handle_data = handle_data
+        original_finalize = downloader.finalize
+        downloader.finalize = finalize
+        download_result = await downloader.run(extra_data={'repo_name': repo_name})
+
+        if remote.policy != Remote.STREAMED:
+            self._save_artifact(download_result, remote_artifact)
+        await response.write_eof()
+        return response
+
+    def _save_artifact(self, download_result, remote_artifact):
+        """
+        Create/Get an Artifact and associate it to a RemoteArtifact and/or ContentArtifact.
+
+        Create (or get if already existing) an :class:`~pulpcore.plugin.models.Artifact`
+        based on the `download_result` and associate it to the `content_artifact` of the given
+        `remote_artifact`. Both the created artifact and the updated content_artifact are saved to
+        the DB.  The `remote_artifact` is also saved for the pull-through caching use case.
+
+        Plugin-writers may overide this method if their content module requires
+        additional/different steps for saving.
+
+        Args:
+            download_result (:class:`~pulpcore.plugin.download.DownloadResult`: The
+                DownloadResult for the downloaded artifact.
+
+            remote_artifact (:class:`~pulpcore.plugin.models.RemoteArtifact`): The
+                RemoteArtifact to associate the Artifact with.
+
+        Returns:
+            The associated :class:`~pulpcore.plugin.models.Artifact`.
+
+        """
+        content_artifact = remote_artifact.content_artifact
+        remote = remote_artifact.remote
+        artifact = Artifact(
+            **download_result.artifact_attributes,
+            file=download_result.path
+        )
+        with transaction.atomic():
+            try:
+                with transaction.atomic():
+                    artifact.save()
+            except IntegrityError:
+                artifact = Artifact.objects.get(artifact.q())
+            update_content_artifact = True
+            if content_artifact._state.adding:
+                # This is the first time pull-through content was requested.
+                rel_path = content_artifact.relative_path
+                c_type = remote.get_remote_artifact_content_type(rel_path)
+                content = c_type.init_from_artifact_and_relative_path(artifact, rel_path)
+                try:
+                    with transaction.atomic():
+                        content.save()
+                        content_artifact.content = content
+                        content_artifact.save()
+                except IntegrityError:
+                    # There is already content for this Artifact
+                    content = c_type.objects.get(content.q())
+                    artifacts = content._artifacts
+                    if artifact.sha256 != artifacts[0].sha256:
+                        raise RuntimeError("The Artifact downloaded during pull-through does not "
+                                           "match the Artifact already stored for the same "
+                                           "content.")
+                    content_artifact = ContentArtifact.objects.get(content=content)
+                    update_content_artifact = False
+                try:
+                    with transaction.atomic():
+                        remote_artifact.content_artifact = content_artifact
+                        remote_artifact.save()
+                except IntegrityError:
+                    # Remote artifact must have already gotten saved during a parallel request
+                    log.info("RemoteArtifact already exists.")
+            if update_content_artifact:
+                content_artifact.artifact = artifact
+                content_artifact.save()
+        return artifact

--- a/pulp_docker/tests/functional/api/test_pull_content.py
+++ b/pulp_docker/tests/functional/api/test_pull_content.py
@@ -5,8 +5,9 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, cli, config, exceptions
-from pulp_smash.pulp3.constants import REPO_PATH
+from pulp_smash.pulp3.constants import ARTIFACTS_PATH, REPO_PATH
 from pulp_smash.pulp3.utils import (
+    delete_orphans,
     get_content,
     gen_distribution,
     gen_repo,
@@ -239,3 +240,206 @@ class PullContentTestCase(unittest.TestCase):
         )
         with self.assertRaises(exceptions.CalledProcessError):
             registry.pull(local_url)
+
+
+class PullLazyContentTestCase(unittest.TestCase):
+    """Verify whether images lazily-served by Pulp can be pulled."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables and delete orphans.
+
+        1. Create a repository.
+        2. Create a remote pointing to external registry with policy=on_demand.
+        3. Sync the repository using the remote and re-read the repo data.
+        4. Create a docker distribution to serve the repository
+        5. Create another docker distribution to the serve the repository version
+
+        This tests targets the following issue:
+
+        * `Pulp #4460 <https://pulp.plan.io/issues/4460>`_
+        """
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.page_handler)
+        cls.teardown_cleanups = []
+
+        delete_orphans(cls.cfg)
+
+        with contextlib.ExitStack() as stack:
+            # ensure tearDownClass runs if an error occurs here
+            stack.callback(cls.tearDownClass)
+
+            # Step 1
+            _repo = cls.client.post(REPO_PATH, gen_repo())
+            cls.teardown_cleanups.append((cls.client.delete, _repo['_href']))
+
+            # Step 2
+            cls.remote = cls.client.post(
+                DOCKER_REMOTE_PATH, gen_docker_remote(policy='on_demand')
+            )
+            cls.teardown_cleanups.append(
+                (cls.client.delete, cls.remote['_href'])
+            )
+
+            # Step 3
+            sync(cls.cfg, cls.remote, _repo)
+            cls.repo = cls.client.get(_repo['_href'])
+            cls.artifact_count = len(cls.client.get(ARTIFACTS_PATH))
+
+            # Step 4.
+            response_dict = cls.client.using_handler(api.task_handler).post(
+                DOCKER_DISTRIBUTION_PATH,
+                gen_distribution(repository=cls.repo['_href'])
+            )
+            distribution_href = response_dict['_href']
+            cls.distribution_with_repo = cls.client.get(distribution_href)
+            cls.teardown_cleanups.append(
+                (cls.client.delete, cls.distribution_with_repo['_href'])
+            )
+
+            # Step 5.
+            response_dict = cls.client.using_handler(api.task_handler).post(
+                DOCKER_DISTRIBUTION_PATH,
+                gen_distribution(repository_version=cls.repo['_latest_version_href'])
+            )
+            distribution_href = response_dict['_href']
+            cls.distribution_with_repo_version = cls.client.get(distribution_href)
+            cls.teardown_cleanups.append(
+                (cls.client.delete, cls.distribution_with_repo_version['_href'])
+            )
+
+            # remove callback if everything goes well
+            stack.pop_all()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean class-wide variable."""
+        for cleanup_function, args in reversed(cls.teardown_cleanups):
+            cleanup_function(args)
+
+    def test_api_returns_same_checksum(self):
+        """Verify that pulp serves image with the same checksum of remote.
+
+        1. Call pulp repository API and get the content_summary for repo.
+        2. Call dockerhub API and get blobsums for synced image.
+        3. Compare the checksums.
+        """
+        # Get local checksums for content synced from remote registy
+        checksums = [
+            content['digest'] for content
+            in get_content(self.repo)[DOCKER_CONTENT_NAME]
+        ]
+
+        # Assert that at least one layer is synced from remote:latest
+        # and the checksum matched with remote
+        self.assertTrue(
+            any(
+                [
+                    result['blobSum'] in checksums
+                    for result in get_docker_hub_remote_blobsums()
+                ]
+            ),
+            'Cannot find a matching layer on remote registry.'
+        )
+
+    def test_pull_image_from_repository(self):
+        """Verify that a client can pull the image from Pulp (lazy).
+
+        1. Using the RegistryClient pull the image from Pulp.
+        2. Pull the same image from remote registry.
+        3. Verify both images has the same checksum.
+        4. Verify that the number of artifacts in Pulp has increased.
+        5. Ensure image is deleted after the test.
+        """
+        registry = cli.RegistryClient(self.cfg)
+        registry.raise_if_unsupported(
+            unittest.SkipTest, 'Test requires podman/docker'
+        )
+
+        local_url = urljoin(
+            self.cfg.get_content_host_base_url(),
+            self.distribution_with_repo['base_path']
+        )
+
+        registry.pull(local_url)
+        self.teardown_cleanups.append((registry.rmi, local_url))
+        local_image = registry.inspect(local_url)
+
+        registry.pull(DOCKER_UPSTREAM_NAME)
+        remote_image = registry.inspect(DOCKER_UPSTREAM_NAME)
+
+        self.assertEqual(
+            local_image[0]['Id'],
+            remote_image[0]['Id']
+        )
+
+        new_artifact_count = len(self.client.get(ARTIFACTS_PATH))
+        self.assertGreater(new_artifact_count, self.artifact_count)
+
+        registry.rmi(DOCKER_UPSTREAM_NAME)
+
+    def test_pull_image_from_repository_version(self):
+        """Verify that a client can pull the image from Pulp (lazy).
+
+        1. Using the RegistryClient pull the image from Pulp.
+        2. Pull the same image from remote registry.
+        3. Verify both images has the same checksum.
+        4. Ensure image is deleted after the test.
+        """
+        registry = cli.RegistryClient(self.cfg)
+        registry.raise_if_unsupported(
+            unittest.SkipTest, 'Test requires podman/docker'
+        )
+
+        local_url = urljoin(
+            self.cfg.get_content_host_base_url(),
+            self.distribution_with_repo_version['base_path']
+        )
+
+        registry.pull(local_url)
+        self.teardown_cleanups.append((registry.rmi, local_url))
+        local_image = registry.inspect(local_url)
+
+        registry.pull(DOCKER_UPSTREAM_NAME)
+        remote_image = registry.inspect(DOCKER_UPSTREAM_NAME)
+
+        self.assertEqual(
+            local_image[0]['Id'],
+            remote_image[0]['Id']
+        )
+        registry.rmi(DOCKER_UPSTREAM_NAME)
+
+    def test_pull_image_with_tag(self):
+        """Verify that a client can pull the image from Pulp with a tag (lazy).
+
+        1. Using the RegistryClient pull the image from Pulp specifying a tag.
+        2. Pull the same image and same tag from remote registry.
+        3. Verify both images has the same checksum.
+        4. Ensure image is deleted after the test.
+        """
+        registry = cli.RegistryClient(self.cfg)
+        registry.raise_if_unsupported(
+            unittest.SkipTest, 'Test requires podman/docker'
+        )
+
+        local_url = urljoin(
+            self.cfg.get_content_host_base_url(),
+            self.distribution_with_repo['base_path']
+        ) + DOCKER_UPSTREAM_TAG
+
+        registry.pull(local_url)
+        self.teardown_cleanups.append((registry.rmi, local_url))
+        local_image = registry.inspect(local_url)
+
+        registry.pull(DOCKER_UPSTREAM_NAME + DOCKER_UPSTREAM_TAG)
+        self.teardown_cleanups.append(
+            (registry.rmi, DOCKER_UPSTREAM_NAME + DOCKER_UPSTREAM_TAG)
+        )
+        remote_image = registry.inspect(
+            DOCKER_UPSTREAM_NAME + DOCKER_UPSTREAM_TAG
+        )
+
+        self.assertEqual(
+            local_image[0]['Id'],
+            remote_image[0]['Id']
+        )


### PR DESCRIPTION
Solution: add support for lazy sync

This patch adds ability to create remotes with policy='on_demand'. When such a remote is used to
sync a repository, the Blobs are not downloaded. Only manifests and manifest lists are saved at
sync time. Blobs are retrieved on demand from clients.

This patch also includes a set of tests that check that you can pull content from a repo that
was synced using a remote that has policy set to 'on_demand'. The tests assert that performing
a docker/podman pull results in more artifacts being stored in Pulp than before the image was
requested.

closes: #4174
https://pulp.plan.io/issues/4174