### PR TITLE
Problem: Schema1 manifest digest is calculated on the unsigned version.

### DIFF
--- a/CHANGES/5037.bugfix
+++ b/CHANGES/5037.bugfix
@@ -1,0 +1,1 @@
+Remove schema1 manifest signature when calculating its digest.


### PR DESCRIPTION
Solution: Remove the signatures when calculating the digest.

closes #5037
https://pulp.plan.io/issues/5037