### PR TITLE
Update tests with on-demand terminology.

### DIFF
--- a/pulp_docker/tests/functional/api/test_crud_remotes.py
+++ b/pulp_docker/tests/functional/api/test_crud_remotes.py
@@ -6,7 +6,10 @@ import unittest
 from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, utils
-from pulp_smash.pulp3.constants import DOWNLOAD_POLICIES
+from pulp_smash.pulp3.constants import (
+    IMMEDIATE_DOWNLOAD_POLICIES,
+    ON_DEMAND_DOWNLOAD_POLICIES,
+)
 
 from pulp_docker.tests.functional.constants import DOCKER_REMOTE_PATH
 from pulp_docker.tests.functional.utils import skip_if, gen_docker_remote
@@ -127,6 +130,8 @@ def _gen_verbose_remote():
     attrs.update({
         'password': utils.uuid4(),
         'username': utils.uuid4(),
-        'policy': choice(DOWNLOAD_POLICIES),
+        'policy': choice(
+            IMMEDIATE_DOWNLOAD_POLICIES + ON_DEMAND_DOWNLOAD_POLICIES
+        ),
     })
     return attrs

--- a/pulp_docker/tests/functional/api/test_pull_content.py
+++ b/pulp_docker/tests/functional/api/test_pull_content.py
@@ -242,8 +242,8 @@ class PullContentTestCase(unittest.TestCase):
             registry.pull(local_url)
 
 
-class PullLazyContentTestCase(unittest.TestCase):
-    """Verify whether images lazily-served by Pulp can be pulled."""
+class PullOnDemandContentTestCase(unittest.TestCase):
+    """Verify whether on-demand served images by Pulp can be pulled."""
 
     @classmethod
     def setUpClass(cls):
@@ -343,7 +343,7 @@ class PullLazyContentTestCase(unittest.TestCase):
         )
 
     def test_pull_image_from_repository(self):
-        """Verify that a client can pull the image from Pulp (lazy).
+        """Verify that a client can pull the image from Pulp (on-demand).
 
         1. Using the RegistryClient pull the image from Pulp.
         2. Pull the same image from remote registry.
@@ -379,7 +379,7 @@ class PullLazyContentTestCase(unittest.TestCase):
         registry.rmi(DOCKER_UPSTREAM_NAME)
 
     def test_pull_image_from_repository_version(self):
-        """Verify that a client can pull the image from Pulp (lazy).
+        """Verify that a client can pull the image from Pulp (on-demand).
 
         1. Using the RegistryClient pull the image from Pulp.
         2. Pull the same image from remote registry.
@@ -410,7 +410,7 @@ class PullLazyContentTestCase(unittest.TestCase):
         registry.rmi(DOCKER_UPSTREAM_NAME)
 
     def test_pull_image_with_tag(self):
-        """Verify that a client can pull the image from Pulp with a tag (lazy).
+        """Verify that a client can pull the image from Pulp with a tag (on-demand).
 
         1. Using the RegistryClient pull the image from Pulp specifying a tag.
         2. Pull the same image and same tag from remote registry.


### PR DESCRIPTION
The names were updated to replace 'lazy' with 'on demand'.

[noissue]