### PR TITLE
Allow Accept header to send multiple values

### DIFF
--- a/pulp_docker/app/registry.py
+++ b/pulp_docker/app/registry.py
@@ -42,9 +42,10 @@ class Registry(Handler):
 
         """
         accepted_media_types = []
-        for header, value in request.raw_headers:
+        for header, values in request.raw_headers:
             if header == b'Accept':
-                accepted_media_types.append(value.decode('UTF-8'))
+                values = [v.strip().decode('UTF-8') for v in values.split(b",")]
+                accepted_media_types.extend(values)
         return accepted_media_types
 
     @staticmethod


### PR DESCRIPTION
closes #5211
https://pulp.plan.io/issues/5211

This will allow the Accept header to use multiple values.

I tested this out with pulling directly with docker, which seems to send one value,
and Katello, where we send multiple values. Both scenarios were able to pull successfully.

This will make it easy for Katello to substitute pulp3 registry url instead of crane where it is supported.