### PR TITLE
Use CONTENT_ORIGIN instead of CONTENT_HOST

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -96,7 +96,7 @@ spec:
     username: pulp
     password: pulp
     admin_password: pulp
-  content_host: $(hostname):24816
+  content_origin: $(hostname):24816
 CRYAML
 
 # Install k3s, lightweight Kubernetes

--- a/CHANGES/5629.misc
+++ b/CHANGES/5629.misc
@@ -1,0 +1,1 @@
+Switch to using ``CONTENT_ORIGIN`` instead of ``CONTENT_HOST`` due to core changing the name.

--- a/pulp_docker/app/serializers.py
+++ b/pulp_docker/app/serializers.py
@@ -108,8 +108,8 @@ class RegistryPathField(serializers.CharField):
         """
         Converts a base_path into a registry path.
         """
-        if settings.CONTENT_HOST:
-            host = settings.CONTENT_HOST
+        if settings.CONTENT_ORIGIN:
+            host = settings.CONTENT_ORIGIN
         else:
             host = self.context['request'].get_host()
         return ''.join([host, '/', value])


### PR DESCRIPTION
pulpcore changed the setting name from CONTENT_HOST to CONTENT_ORIGIN.

Required PR: https://github.com/pulp/pulpcore/pull/353

https://pulp.plan.io/issues/5629
re #5629