### PR TITLE
Revert "Explicitly define ref_name on the serializer."

### DIFF
--- a/CHANGES/5562.bugfix
+++ b/CHANGES/5562.bugfix
@@ -1,1 +1,0 @@
-Explicitly define ref_name on the serializer.

--- a/pulp_docker/app/serializers.py
+++ b/pulp_docker/app/serializers.py
@@ -41,7 +41,6 @@ class TagSerializer(SingleArtifactContentSerializer):
             'tagged_manifest',
         )
         model = models.Tag
-        ref_name = f'{model._meta.app_label}_{model._meta.model_name}'
 
 
 class ManifestSerializer(SingleArtifactContentSerializer):


### PR DESCRIPTION
This reverts commit 8689733ca94c8d67573219e934aa18b2043ec156.

`ref_name` is set automatically now (see https://pulp.plan.io/issues/5574).

[noissue]