### PR TITLE
Use CONTENT_ORIGIN instead of CONTENT_HOST

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -96,7 +96,7 @@ spec:
     password: pulp
     admin_password: pulp
   pulp_settings:
-     content_host: $(hostname):24816
+     content_origin: http://$(hostname):24816
      token_server: $(hostname):24816/token
      private_key_path: /var/lib/pulp/tmp/private.pem
      public_key_path: /var/lib/pulp/tmp/public.pem

--- a/CHANGES/5629.misc
+++ b/CHANGES/5629.misc
@@ -1,0 +1,1 @@
+Switch to using ``CONTENT_ORIGIN`` instead of ``CONTENT_HOST`` due to core changing the name.

--- a/pulp_docker/app/authorization.py
+++ b/pulp_docker/app/authorization.py
@@ -16,7 +16,7 @@ from pulpcore.plugin.content import Handler
 
 TOKEN_EXPIRATION_TIME = 300
 
-KNOWN_SERVICES = [settings.CONTENT_HOST]
+KNOWN_SERVICES = [settings.CONTENT_ORIGIN]
 ANONYMOUS_USER = ''
 EMPTY_ACCESS_SCOPE = '::'
 

--- a/pulp_docker/app/serializers.py
+++ b/pulp_docker/app/serializers.py
@@ -107,8 +107,8 @@ class RegistryPathField(serializers.CharField):
         """
         Converts a base_path into a registry path.
         """
-        if settings.CONTENT_HOST:
-            host = settings.CONTENT_HOST
+        if settings.CONTENT_ORIGIN:
+            host = settings.CONTENT_ORIGIN
         else:
             host = self.context['request'].get_host()
         return ''.join([host, '/', value])

--- a/pulp_docker/app/token_verification.py
+++ b/pulp_docker/app/token_verification.py
@@ -98,7 +98,7 @@ class TokenVerifier:
         realm="https://token",service="docker.io",scope="repository:my-app:push".
         """
         realm = f'{self.request.scheme}://{settings.TOKEN_SERVER}'
-        authenticate_string = f'Bearer realm="{realm}",service="{settings.CONTENT_HOST}"'
+        authenticate_string = f'Bearer realm="{realm}",service="{settings.CONTENT_ORIGIN}"'
 
         if not self._is_verifying_root_endpoint():
             scope = f'repository:{source_path}:pull'
@@ -132,7 +132,7 @@ class TokenVerifier:
         return {
             'algorithms': [settings.TOKEN_SIGNATURE_ALGORITHM],
             'issuer': settings.TOKEN_SERVER,
-            'audience': settings.CONTENT_HOST
+            'audience': settings.CONTENT_ORIGIN
         }
 
     def contains_accessible_actions(self, decoded_token):


### PR DESCRIPTION
pulpcore changed the setting name from CONTENT_HOST to CONTENT_ORIGIN.

Required PR: pulp/pulpcore#358

https://pulp.plan.io/issues/5629
re #5629