### PR TITLE
3.2.6 cps

### DIFF
--- a/docs/user-guide/release-notes/3.2.x.rst
+++ b/docs/user-guide/release-notes/3.2.x.rst
@@ -1,6 +1,18 @@
 3.2 Release Notes
 =================
 
+=======
+3.2.6
+-----
+
+Bug Fixes:
+**********
+
+* Can't import containers created with Buildah
+
+See the full list of :fixedbugs_pulp_docker:`3.2.6`.
+
+
 3.2.5
 -----
 

--- a/plugins/pulp_docker/plugins/importers/upload.py
+++ b/plugins/pulp_docker/plugins/importers/upload.py
@@ -407,6 +407,7 @@ class AddUnits(PluginStep):
             if isinstance(item, models.Blob):
                 blobs = repository.find_repo_content_units(
                     repository=self.get_repo().repo_obj,
+                    repo_content_unit_q=Q(unit_type_id=item._content_type_id),
                     units_q=Q(digest=item.digest),
                     limit=1)
                 if tuple(blobs):


### PR DESCRIPTION
Fix upload of docker image

closes #4095
https://pulp.plan.io/issues/4095

(cherry picked from commit 9375ec84064b96b576250f6bc3cbbbb358f1cfae)