### PR TITLE
Improve error message for registry errors

### DIFF
--- a/plugins/pulp_docker/plugins/registry.py
+++ b/plugins/pulp_docker/plugins/registry.py
@@ -545,6 +545,15 @@ class V2Repository(object):
         """
         if report.error_report.get('response_code') == httplib.UNAUTHORIZED:
             # docker hub returns 401 for repos that don't exist, so we cannot disambiguate.
-            raise IOError(_('Unauthorized or Not Found'))
+            raise IOError(_('401 Client Error: \'Unauthorized or Not Found\' for url {0}'.format(
+                report.url)))
         else:
-            raise IOError(report.error_msg)
+            code = report.error_report.get('response_code')
+            if code >= 400 and code < 500:
+                raise IOError('{0} Client Error: \'{1}\' for url: {2}'.format(
+                    code, report.error_msg, report.url))
+            elif code >= 500 and code < 600:
+                raise IOError('{0} Server Error: \'{1}\' for url: {2}'.format(
+                    code, report.error_msg, report.url))
+            else:
+                raise IOError('\'{0}\' for url {1}'.format(report.error_msg, report.url))

--- a/plugins/test/unit/plugins/test_registry.py
+++ b/plugins/test/unit/plugins/test_registry.py
@@ -640,7 +640,22 @@ class TestV2Repository(unittest.TestCase):
         with self.assertRaises(IOError) as assertion:
             registry.V2Repository._raise_path_error(report)
 
-        self.assertEqual(assertion.exception.message, report.error_msg)
+        self.assertEqual(assertion.exception.message,
+                         '404 Client Error: \'oops\' for url: http://foo/bar')
+
+    def test__raise_path_server_error(self):
+        """
+        For server errors a slightly different message should be used.
+        """
+        report = DownloadReport('http://foo/bar', '/a/b/c')
+        report.error_report = {'response_code': httplib.INTERNAL_SERVER_ERROR}
+        report.error_msg = 'oops'
+
+        with self.assertRaises(IOError) as assertion:
+            registry.V2Repository._raise_path_error(report)
+
+        self.assertEqual(assertion.exception.message,
+                         '500 Server Error: \'oops\' for url: http://foo/bar')
 
     def test__raise_path_error_unathorized(self):
         """
@@ -657,7 +672,8 @@ class TestV2Repository(unittest.TestCase):
 
         # not worrying about what the exact contents are; just that the function added its
         # own message
-        self.assertNotEqual(assertion.exception.message, report.error_msg)
+        self.assertEqual(assertion.exception.message,
+                         '401 Client Error: \'Unauthorized or Not Found\' for url http://foo/bar')
         self.assertTrue(len(assertion.exception.message) > 0)
 
     @mock.patch('pulp_docker.plugins.registry.HTTPThreadedDownloader')


### PR DESCRIPTION
https://pulp.plan.io/issues/7214

The expanded messages are modelled after the requests library. The motivation for the change was that the current messages were misleading for the end users.