### PR TITLE
Use Downloader.extra_headers instead of session.headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: trusty
 python:
   - "2.6"
   - "2.7"

--- a/plugins/pulp_docker/plugins/auth_util.py
+++ b/plugins/pulp_docker/plugins/auth_util.py
@@ -90,7 +90,7 @@ def request_token(downloader, request, auth_header, repo_name):
     token_data = StringIO()
     token_request = DownloadRequest(token_url, token_data)
     _logger.debug("Requesting token from {url}".format(url=token_url))
-    downloader.session.headers.pop('Authorization', None)
+    downloader.extra_headers.pop('Authorization', None)
     report = downloader.download_one(token_request)
     if report.state == report.DOWNLOAD_FAILED:
         return report

--- a/plugins/pulp_docker/plugins/importers/sync.py
+++ b/plugins/pulp_docker/plugins/importers/sync.py
@@ -454,16 +454,16 @@ class AuthDownloadStep(publish_step.DownloadStep):
             if auth_header is None:
                 raise IOError("401 responses are expected to contain authentication information")
             if "Basic" in auth_header:
-                self.downloader.session.headers = auth_util.update_basic_auth_header(
-                    self.downloader.session.headers,
+                self.downloader.extra_headers = auth_util.update_basic_auth_header(
+                    self.downloader.extra_headers,
                     self.basic_auth_username, self.basic_auth_password)
                 _logger.debug(_('Download unauthorized, retrying with basic authentication'))
             else:
                 token = auth_util.request_token(self.parent.index_repository.auth_downloader,
                                                 request, auth_header,
                                                 self.parent.index_repository.name)
-                self.downloader.session.headers = auth_util.update_token_auth_header(
-                    self.downloader.session.headers, token)
+                self.downloader.extra_headers = auth_util.update_token_auth_header(
+                    self.downloader.extra_headers, token)
                 _logger.debug("Download unauthorized, retrying with new bearer token.")
 
             # Events must be false or download_failed will recurse


### PR DESCRIPTION
In recent change in nectar session in downloader was removed from
shared space for all threads and for every request new Session
object is created. To be able to provide same functionality
extra_headers dictionary was added to Downloader object. This commit
modifies code to use extra_headers instead of session.headers